### PR TITLE
Fix to allow Firstname with two characters

### DIFF
--- a/components/ruby/lib/chef-licensing/tui_engine/tui_actions.rb
+++ b/components/ruby/lib/chef-licensing/tui_engine/tui_actions.rb
@@ -43,7 +43,7 @@ module ChefLicensing
 
       def is_user_name_valid?(input)
         user_name = input[:gather_user_last_name_for_license_generation] || input[:gather_user_first_name_for_license_generation]
-        (user_name =~ /\A[a-z_A-Z\-\`]{3,16}\Z/) == 0
+        (user_name =~ /\A[a-z_A-Z\-\`]{2,16}\Z/) == 0
       end
 
       def is_email_valid?(input)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Firstname is not allowed to enter names with two characters. This will then fail for Users who has name with two characters for e.g. `Ed` is a valid name.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
