### PR TITLE
[WIP] CHEF-58: Create Free License Text User Interface in Client Library

### DIFF
--- a/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
@@ -89,9 +89,9 @@ interactions:
   ask_for_license_type_on_renewal:
     prompt_type: "select"
     messages: ["\nSelect the type of license below and then enter user details" , ["1.Free license", "2.Commercial license"]]
-    paths: [free_license_selection, commercial_license_selection]
+    paths: [check_if_user_has_active_trial_license, commercial_license_selection]
     response_path_map:
-      "1.Free license": free_license_selection
+      "1.Free license": check_if_user_has_active_trial_license
       "2.Commercial license": commercial_license_selection
 
   ask_if_user_has_license_id:
@@ -213,14 +213,30 @@ interactions:
   ask_for_license_type:
     prompt_type: "select"
     messages: ["\nSelect the type of license below and then enter user details" , [ "1.Free license", "2.Trial license", "3.Commercial license"]]
-    paths: [free_license_selection, commercial_license_selection, trial_license_selection]
+    paths: [check_if_user_has_active_trial_license, commercial_license_selection, trial_license_selection]
     response_path_map:
-      "1.Free license": free_license_selection
+      "1.Free license": check_if_user_has_active_trial_license
       "2.Trial license": trial_license_selection
       "3.Commercial license": commercial_license_selection
 
+  check_if_user_has_active_trial_license:
+    action: check_user_has_active_trial_license
+    paths: [free_license_generation_not_allowed, free_license_selection]
+    response_path_map:
+      "true": free_license_generation_not_allowed
+      "false": free_license_selection
+
+  free_license_generation_not_allowed:
+    messages: "! [WARNING] You already have an active trial license."
+    prompt_type: "warn"
+    paths: [exit]
+
   free_license_selection:
+    # TODO: Change messages "Free license is subject to..." to proper message after discussing
+    # Change the color if required.
     messages: |
+
+      Free license is subject to personal and non-commercial use only.
 
       You have selected:
         Free License

--- a/components/ruby/lib/chef-licensing/tui_engine/tui_actions.rb
+++ b/components/ruby/lib/chef-licensing/tui_engine/tui_actions.rb
@@ -7,6 +7,7 @@ require_relative "../license_key_fetcher/base"
 require_relative "../config"
 require_relative "../list_license_keys"
 require "tty-spinner"
+require_relative "../license_key_fetcher"
 
 module ChefLicensing
   class TUIEngine
@@ -162,6 +163,27 @@ module ChefLicensing
 
       def display_license_info(inputs)
         ChefLicensing::ListLicenseKeys.display_overview({ license_keys: [license_id] })
+      end
+
+      def check_user_has_active_trial_license(inputs)
+        # TODO:
+        # fetch the licenses on the system
+        # check if any of the licenses are trial licenses and active
+        # if yes, then return true
+        # else return false
+
+        license_keys = ChefLicensing::LicenseKeyFetcher.fetch
+
+        return false if license_keys.empty?
+
+        license_keys.each do |license_key|
+          # TODO: uncomment the below code once the PR #79 is merged
+          # license_type = ChefLicensing::LicenseKeyValidator.validate_and_fetch_license_type([license_key])
+          # if license_type == "trial"
+          #   return true
+          # end
+        end
+        false
       end
     end
   end


### PR DESCRIPTION
## Description

TODO:
- Wait for PR #79 to be merged to use the `validate_and_fetch_license_type` method or use that branch if required
- Confirm the flow with UX diagrams available on figma

TO CONFIRM:
- **Do we not allow the user to add a free license when an active trial license is effect as part of this PR?**

This PR includes:
- Updates the TUI entry for Free License Generation flow according to UX diagram
- Do not allow the user to generate a free license when an active trial license is in effect
- Display message indicating it is for personal and non-commercial use

## Related Issue
**CHEF-58: Create Free License Text User Interface in Client Library**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
