### PR TITLE
CHEF-54: Update serial number regex and test associated with the change

### DIFF
--- a/components/ruby/lib/chef-licensing/license_key_fetcher/base.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/base.rb
@@ -2,13 +2,13 @@ module ChefLicensing
   class LicenseKeyFetcher
     class Base
       # @example LICENSE UUID: tmns-58555821-925e-4a27-8fdc-e79dae5a425b-9763
-      # @example SERIAL NUMBER: A8BCD1XS2B4F6FYBWG8TE0N49
+      # @example SERIAL NUMBER: A8BCD1XS2B4F6FYBWG8TE0N490
       # 4[license type]-(8-4-4-4-12)[GUID]-4[timestamp]
       LICENSE_KEY_REGEX = "([a-z]{4}-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-[0-9]{1,4})".freeze
       LICENSE_KEY_PATTERN_DESC = "Hexadecimal".freeze
-      # Serial number is a 25 character alphanumeric string
-      SERIAL_KEY_REGEX = "([A-Z0-9]{25})".freeze
-      SERIAL_KEY_PATTERN_DESC = "25 character alphanumeric string".freeze
+      # Serial number is a 26 character alphanumeric string
+      SERIAL_KEY_REGEX = "([A-Z0-9]{26})".freeze
+      SERIAL_KEY_PATTERN_DESC = "26 character alphanumeric string".freeze
       QUIT_KEY_REGEX = "(q|Q)".freeze
 
       def self.verify_and_extract_license(license_key)

--- a/components/ruby/spec/license_key_fetcher_spec.rb
+++ b/components/ruby/spec/license_key_fetcher_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe ChefLicensing::LicenseKeyFetcher do
       end
     end
 
-    context "when the license key is in correct format of serial number but less than 25 characters" do
+    context "when the license key is in correct format of serial number but less than 26 characters" do
       let(:argv)  { ["--chef-license-key=A8BCD1XS2B4F6FYBWG8TE0N4"] }
       let(:env) { {} }
 
@@ -313,7 +313,7 @@ RSpec.describe ChefLicensing::LicenseKeyFetcher do
     end
 
     context "when the license key is in the correct format of serial number" do
-      let(:argv)  { ["--chef-license-key=A8BCD1XS2B4F6FYBWG8TE0N49"] }
+      let(:argv)  { ["--chef-license-key=A8BCD1XS2B4F6FYBWG8TE0N490"] }
       let(:env) { {} }
 
       let(:opts) {
@@ -329,7 +329,7 @@ RSpec.describe ChefLicensing::LicenseKeyFetcher do
       let(:license_key_fetcher) { ChefLicensing::LicenseKeyFetcher.new(opts) }
 
       it "returns the license key" do
-        expect(license_key_fetcher.fetch).to eq(["A8BCD1XS2B4F6FYBWG8TE0N49"])
+        expect(license_key_fetcher.fetch).to eq(["A8BCD1XS2B4F6FYBWG8TE0N490"])
       end
     end
   end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This PR updates the serial number's regex and test associated with the change. The initial serial number provided was a 25 alphanumeric characters which is a 26 now.

## Related Issue
**CHEF-54: Accept Serial Number license format as well as GUID**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
