### PR TITLE
CHEF-1957: Update method-name and responsibilities

### DIFF
--- a/components/ruby/lib/chef-licensing.rb
+++ b/components/ruby/lib/chef-licensing.rb
@@ -47,6 +47,11 @@ module ChefLicensing
 
     # @note no in-memory caching of the licenses so that it fetches updated licenses always
     def license_keys
+      ChefLicensing::LicenseKeyFetcher.fetch
+    end
+
+    # @note fetch_and_persist is invoked by chef-products to fetch and persist the license keys
+    def fetch_and_persist
       ChefLicensing::LicenseKeyFetcher.fetch_and_persist
     end
 


### PR DESCRIPTION
## Description
**Current behaviour of chef-licensing library**:
- The methods`check_software_entitlement!` and `check_feature_entitlement!` invokes the `client` API call with the license keys as parameter, which is fetched using the `license_keys` method. 
- However, `license_keys` has the responsibility of `fetch_and_persist`. This causes an issue to invoke `fetch_and_persist` multiple times(currently twice) when `check_software_entitlement!` or `check_feature_entitlement!` is invoked.

**Changes Introduced**:
- The responsibility of `license_keys` method is updated to fetch the license and not persist.
- `fetch_and_persist` method is introduced to perform the fetching and persisting of license keys.

## Related Issue
**CHEF-1957: Inspec prime calls chef-licensing fetch_and_persist twice during one flow.**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
