### PR TITLE
CHEF-2314 No prompt for same license id addition using env and argument

### DIFF
--- a/components/ruby/lib/chef-licensing/license_key_fetcher.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher.rb
@@ -49,7 +49,7 @@ module ChefLicensing
       logger.debug "License Key fetcher examining CLI arg checks"
       new_keys = fetch_license_key_from_arg
       license_type = validate_and_fetch_license_type(new_keys)
-      if license_type && !check_license_restriction_and_add_license(new_keys, license_type)
+      if license_type && !unrestricted_license_added?(new_keys, license_type)
         # break the flow after the prompt if there is a restriction in adding license
         return new_keys
       end
@@ -57,7 +57,7 @@ module ChefLicensing
       logger.debug "License Key fetcher examining ENV checks"
       new_keys = fetch_license_key_from_env
       license_type = validate_and_fetch_license_type(new_keys)
-      if license_type && !check_license_restriction_and_add_license(new_keys, license_type)
+      if license_type && !unrestricted_license_added?(new_keys, license_type)
         # break the flow after the prompt if there is a restriction in adding license
         return new_keys
       end
@@ -229,7 +229,7 @@ module ChefLicensing
       prompt_fetcher.fetch
     end
 
-    def check_license_restriction_and_add_license(new_keys, license_type)
+    def unrestricted_license_added?(new_keys, license_type)
       if license_restricted?(license_type)
         # Existing license keys are fetched to compare if old license key or a new one is added.
         existing_license_keys_in_file = file_fetcher.fetch_license_keys_based_on_type(license_type)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
No prompt for same license id addition using env and argument way of license addition.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
