### PR TITLE
CHEF-3278 Display validity for free license as Unlimited in the license details

### DIFF
--- a/components/ruby/lib/chef-licensing/list_license_keys.rb
+++ b/components/ruby/lib/chef-licensing/list_license_keys.rb
@@ -57,19 +57,24 @@ module ChefLicensing
     def display_overview
       output.puts "------------------------------------------------------------"
       licenses_metadata.each do |license|
-        # find the number of days left for the license to expire
-        validity = (Date.parse(license.expiration_date) - Date.today).to_i
+        # Sets the validity text for a free license as "Unlimited" and displays the number of days for others.
+        validity = if license.license_type == "free"
+                     "Unlimited"
+                   else
+                     # find the number of days left for the license to expire
+                     days = (Date.parse(license.expiration_date) - Date.today).to_i
+                     "#{days > 0 ? days : 0} #{"Day".pluralize(days)}"
+                   end
         num_of_units = license.limits&.first&.usage_limit || 0
         num_of_units = num_of_units == -1 ? "Unlimited" : num_of_units
         unit_measure = license.limits&.first&.usage_measure || "unit"
-
         output.puts <<~LICENSE
             #{pastel.bold("License Details")}
               Asset Name       : #{license.limits.first.software}
               License ID       : #{license.id}
               Type             : #{license.license_type.capitalize}
               Status           : #{license.status.capitalize}
-              Validity         : #{validity > 0 ? validity : 0} #{"Day".pluralize(validity)}
+              Validity         : #{validity}
               No. Of Units     : #{num_of_units} #{unit_measure.capitalize.pluralize(num_of_units)}
             ------------------------------------------------------------
         LICENSE


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
After a user enters a free license via the TUI, a brief license detail contains the Validity in a number of days.
Currently, the value for validity is displayed according to the response received from the licensing server.
As per the new UX suggestions, this PR includes the change to display validity as "Unlimited" for the free license type.

Before Changes
<img width="1309" alt="Screenshot 2023-06-01 at 6 19 21 PM" src="https://github.com/chef/chef-licensing/assets/4181545/7588579c-80e5-4ea3-b786-50b88e85b06a">


After Changes
<img width="1253" alt="Screenshot 2023-06-01 at 6 07 27 PM" src="https://github.com/chef/chef-licensing/assets/4181545/926f6c98-7502-45e3-9da8-c54ed3a9e484">

<img width="1227" alt="Screenshot 2023-06-01 at 6 06 22 PM" src="https://github.com/chef/chef-licensing/assets/4181545/b5d3ee34-11c0-4dad-885d-16a4cd971a77">
## Related Issue



<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
