### PR TITLE
FIX: Do not raise exception as we handled and logged it already

### DIFF
--- a/components/ruby/lib/chef-licensing/license_key_fetcher/file.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/file.rb
@@ -257,7 +257,7 @@ module ChefLicensing
       def handle_error(e, message = nil)
         logger.warn "#{message}\n\t#{e.message}"
         logger.debug "#{e.backtrace.join("\n\t")}"
-        raise e
+        e
       end
     end
   end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The initial logic to handle non-writable was to rescue the exception and log it. The exception wasn't raised after it was logged. This PR is reverting back the same logic.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
