### PR TITLE
Return license server url to config in all case

### DIFF
--- a/components/ruby/lib/chef-licensing/license_key_fetcher/file.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/file.rb
@@ -129,11 +129,16 @@ module ChefLicensing
           end
         end
 
-        write_license_file(license_key_file_path)
-        @license_server_url = @contents[:license_server_url]
+        # Ensure the license server URL is returned to the caller in all cases
+        # (even if it's not persisted to the licenses.yaml file on the disk)
+        begin
+          write_license_file(license_key_file_path)
+        rescue StandardError => e
+          handle_error(e)
+        ensure
+          @license_server_url = @contents[:license_server_url]
+        end
         @license_server_url
-      rescue StandardError => e
-        handle_error(e)
       end
 
       def self.default_file_location


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR introduce changes to `fetch_or_persist_url` to return license server url irrespective of the URL was successfully written to file or not. This is important for scenarios when file is not writable.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
