### PR TITLE
HACK: Remove warn level log message to fix omnibus test for inspec

### DIFF
--- a/components/ruby/lib/chef-licensing/license_key_fetcher/file.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/file.rb
@@ -260,7 +260,6 @@ module ChefLicensing
       end
 
       def handle_error(e, message = nil)
-        logger.warn "#{message}\n\t#{e.message}"
         logger.debug "#{e.backtrace.join("\n\t")}"
         e
       end


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, what problems does it solve? -->

This PR attempts a fix to an issue in the omnibus build where a warning-level logging message is displayed in the STDOUT, causing the inspec test to fail. The proposed solution involves removing the warning message to resolve the problem.

## Related Issue
Part of: **CHEF-63: Resolve any omnibus build issues for inspec 6**
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
