### PR TITLE
CHEF-3698: Add `--chef-license-server` to Chef Licensing CLI Flags

### DIFF
--- a/components/ruby/lib/chef-licensing/cli_flags/mixlib_cli.rb
+++ b/components/ruby/lib/chef-licensing/cli_flags/mixlib_cli.rb
@@ -15,6 +15,11 @@ module ChefLicensing
           long: "--chef-license-key KEY",
           description: "Add a new Chef License Key to the license store. Ignores duplicates.",
           required: false
+
+        klass.option :chef_license_server,
+          long: "--chef-license-server URL",
+          description: "Add a custom Chef License Server URL. Overrides the global license server URL.",
+          required: false
       end
 
     end

--- a/components/ruby/lib/chef-licensing/cli_flags/thor.rb
+++ b/components/ruby/lib/chef-licensing/cli_flags/thor.rb
@@ -12,6 +12,10 @@ module ChefLicensing
         klass.class_option :chef_license_key,
           type: :string,
           desc: "Add a new Chef License Key to the license store. Ignores duplicates."
+
+        klass.class_option :chef_license_server,
+          type: :string,
+          desc: "Add a custom Chef License Server URL. Overrides the global license server URL."
       end
     end
   end


### PR DESCRIPTION
## Description
This PR update adds the `--chef-license-server` option to the Chef Licensing CLI flags. 

- It is necessary for InSpec or other products that use the chef-licensing gem to be able to specify the license server URL through a command-line argument. 
- The option flag will also be displayed in the help information.

## Related Issue
**CHEF-3698: Add `--chef-license-server` to inspec usage help**

## Output of `inspec help`
```
❯ bundle exec inspec help
Commands:
  inspec archive PATH                                  # Archive a profile to a tar file (default) or zip file.
  inspec automate SUBCOMMAND or compliance SUBCOMMAND  # Chef Automate commands
  inspec check PATH                                    # Verify the metadata in the `inspec.yml` file, verify that control blocks have the correct fields (title, description, impact), and...
  inspec clear_cache                                   # clears the InSpec cache. Useful for debugging.
  inspec detect                                        # detects the target OS.
  inspec env                                           # Outputs shell-appropriate completion configuration.
  inspec exec LOCATIONS                                # Run all test files at the specified locations.
  inspec export PATH                                   # read the profile in PATH and generate a summary in the given format.
  inspec habitat SUBCOMMAND                            # Manage Habitat with Chef InSpec
  inspec help [COMMAND]                                # Describe available commands or one specific command
  inspec init SUBCOMMAND                               # Generate InSpec code
  inspec json PATH                                     # read all tests in the PATH and generate a JSON summary.
  inspec license SUBCOMMAND [options]                  # Manage Chef InSpec license
  inspec parallel SUBCOMMAND [options]                 # Runs Chef InSpec operations parallely
  inspec plugin SUBCOMMAND                             # Manage Chef InSpec and Train plugins
  inspec shell                                         # open an interactive debugging shell.
  inspec sign SUBCOMMAND                               # Manage Chef InSpec profile signing.
  inspec supermarket SUBCOMMAND ...                    # Supermarket commands
  inspec vendor PATH                                   # Download all dependencies and generate a lockfile in a `vendor` directory
  inspec version                                       # prints the version of this tool.

Options:
  l, [--log-level=LOG_LEVEL]                        # Set the log level: info (default), debug, warn, error
     [--log-location=LOG_LOCATION]                  # Location to send diagnostic log messages to. (default: $stdout or Inspec::Log.error)
     [--diagnose], [--no-diagnose]                  # Show diagnostics (versions, configurations)
     [--color], [--no-color]                        # Use colors in output.
     [--interactive], [--no-interactive]            # Allow or disable user interaction
     [--disable-user-plugins]                       # Disable loading all plugins that the user installed.
     [--enable-telemetry], [--no-enable-telemetry]  # Allow or disable telemetry
     [--chef-license=CHEF_LICENSE]                  # Accept the license for this product and any contained products: accept, accept-no-persist, accept-silent
     [--chef-license-key=CHEF_LICENSE_KEY]          # Add a new Chef License Key to the license store. Ignores duplicates.
     [--chef-license-server=CHEF_LICENSE_SERVER]    # Add a custom Chef License Server URL. Overrides the global license server URL.

Chef Compliance has three tiers of licensing:

* Free-Tier
  Users are limited to audit maximum of 10 targets
  Entitled for personal or non-commercial use

* Trial
  Entitled for unlimited number of targets
  Entitled for 30 days only
  Entitled for commercial use

* Commercial
  Entitled for purchased number of targets
  Entitled for period of subscription purchased
  Entitled for commercial use

inspec license add: This command helps users to generate or add an additional license

For more information please visit:
www.chef.io/licensing/faqs

About Chef InSpec:
  Patents: chef.io/patents

```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
