### PR TITLE
CHEF-3768: Display Target or Node as the unit measure depending upon the Chef Product (UI/UX Change)

### DIFF
--- a/components/ruby/lib/chef-licensing/license_key_fetcher.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher.rb
@@ -189,6 +189,8 @@ module ChefLicensing
 
       # default values
       extra_info[:chef_product_name] = ChefLicensing::Config.chef_product_name&.capitalize
+      # Note: The unit measure is decided by the UX/Product.
+      extra_info[:unit_measure] = ChefLicensing::Config.chef_product_name&.downcase == "inspec" ? "targets" : "nodes"
       if license
         extra_info[:license_type] = license.license_type.capitalize
         extra_info[:number_of_days_in_expiration] = license.number_of_days_in_expiration

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
@@ -107,7 +107,7 @@ interactions:
 
         Get a Commercial License to receive bug fixes, updates
         and new features.
-        Get a Free License to scan limited  <%= input[:unit_measure] %>.
+        Get a Free License to scan limited <%= input[:unit_measure] %>.
       ------------------------------------------------------------
     prompt_type: "say"
     paths: [fetch_license_id]
@@ -263,7 +263,8 @@ interactions:
       ]]
     paths: [free_license_disclaimer, commercial_license_selection, exit]
     response_path_map:
-      "1. Free License\n     Validity: Unlimited\n     No. of units: 10 <%= input[:unit_measure] %>\n": free_license_disclaimer
+      "1. Free License\n     Validity: Unlimited\n     No. of units: 10 nodes\n": free_license_disclaimer
+      "1. Free License\n     Validity: Unlimited\n     No. of units: 10 targets\n": free_license_disclaimer
       "2. Commercial License\n": commercial_license_selection
       "3. Quit license generation": exit
 
@@ -277,7 +278,8 @@ interactions:
       ]]
     paths: [trial_license_selection, commercial_license_selection, exit]
     response_path_map:
-      "1. Trial License\n     Validity: 30 Days\n     No. of units: Unlimited <%= input[:unit_measure] %>\n": trial_license_selection
+      "1. Trial License\n     Validity: 30 Days\n     No. of units: Unlimited nodes\n": trial_license_selection
+      "1. Trial License\n     Validity: 30 Days\n     No. of units: Unlimited targets\n": trial_license_selection
       "2. Commercial License\n": commercial_license_selection
       "3. Quit license generation": exit
 
@@ -292,8 +294,10 @@ interactions:
       ]]
     paths: [free_license_disclaimer, commercial_license_selection, trial_license_selection, exit]
     response_path_map:
-      "1. Free License\n     Validity: Unlimited\n     No. of units: 10 <%= input[:unit_measure] %>\n": free_license_disclaimer
-      "2. Trial License\n     Validity: 30 Days\n     No. of units: Unlimited <%= input[:unit_measure] %>\n": trial_license_selection
+      "1. Free License\n     Validity: Unlimited\n     No. of units: 10 nodes\n": free_license_disclaimer
+      "1. Free License\n     Validity: Unlimited\n     No. of units: 10 targets\n": free_license_disclaimer
+      "2. Trial License\n     Validity: 30 Days\n     No. of units: Unlimited nodes\n": trial_license_selection
+      "2. Trial License\n     Validity: 30 Days\n     No. of units: Unlimited targets\n": trial_license_selection
       "3. Commercial License\n": commercial_license_selection
       "4. Quit license generation": exit
 

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
@@ -92,7 +92,7 @@ interactions:
 
         Get a Commercial License to receive bug fixes, updates
         and new features.
-        Get a Free License to scan limited targets.
+        Get a Free License to scan limited <%= input[:unit_measure] %>.
 
         To get a new license, run <%= input[:pastel].bold("#{ChefLicensing::Config.chef_executable_name} license add")%>
         and select a license type.
@@ -107,7 +107,7 @@ interactions:
 
         Get a Commercial License to receive bug fixes, updates
         and new features.
-        Get a Free License to scan limited targets.
+        Get a Free License to scan limited  <%= input[:unit_measure] %>.
       ------------------------------------------------------------
     prompt_type: "say"
     paths: [fetch_license_id]
@@ -257,13 +257,13 @@ interactions:
     prompt_type: "select"
     messages: ["Select the type of license below and then enter user details\n" ,
       [
-      "1. Free License\n     Validity: Unlimited\n     No. of targets: 10\n",
+      "1. Free License\n     Validity: Unlimited\n     No. of units: 10 <%= input[:unit_measure] %>\n",
       "2. Commercial License\n",
       "3. Quit license generation"
       ]]
     paths: [free_license_disclaimer, commercial_license_selection, exit]
     response_path_map:
-      "1. Free License\n     Validity: Unlimited\n     No. of targets: 10\n": free_license_disclaimer
+      "1. Free License\n     Validity: Unlimited\n     No. of units: 10 <%= input[:unit_measure] %>\n": free_license_disclaimer
       "2. Commercial License\n": commercial_license_selection
       "3. Quit license generation": exit
 
@@ -271,13 +271,13 @@ interactions:
     prompt_type: "select"
     messages: ["Select the type of license below and then enter user details\n" ,
       [
-      "1. Trial License\n     Validity: 30 Days\n     No. of targets: Unlimited\n",
+      "1. Trial License\n     Validity: 30 Days\n     No. of units: Unlimited <%= input[:unit_measure] %>\n",
       "2. Commercial License\n",
       "3. Quit license generation"
       ]]
     paths: [trial_license_selection, commercial_license_selection, exit]
     response_path_map:
-      "1. Trial License\n     Validity: 30 Days\n     No. of targets: Unlimited\n": trial_license_selection
+      "1. Trial License\n     Validity: 30 Days\n     No. of units: Unlimited <%= input[:unit_measure] %>\n": trial_license_selection
       "2. Commercial License\n": commercial_license_selection
       "3. Quit license generation": exit
 
@@ -285,15 +285,15 @@ interactions:
     prompt_type: "select"
     messages: ["Select the type of license below and then enter user details\n" ,
       [
-      "1. Free License\n     Validity: Unlimited\n     No. of targets: 10\n",
-      "2. Trial License\n     Validity: 30 Days\n     No. of targets: Unlimited\n",
+      "1. Free License\n     Validity: Unlimited\n     No. of units: 10 <%= input[:unit_measure] %>\n",
+      "2. Trial License\n     Validity: 30 Days\n     No. of units: Unlimited <%= input[:unit_measure] %>\n",
       "3. Commercial License\n",
       "4. Quit license generation"
       ]]
     paths: [free_license_disclaimer, commercial_license_selection, trial_license_selection, exit]
     response_path_map:
-      "1. Free License\n     Validity: Unlimited\n     No. of targets: 10\n": free_license_disclaimer
-      "2. Trial License\n     Validity: 30 Days\n     No. of targets: Unlimited\n": trial_license_selection
+      "1. Free License\n     Validity: Unlimited\n     No. of units: 10 <%= input[:unit_measure] %>\n": free_license_disclaimer
+      "2. Trial License\n     Validity: 30 Days\n     No. of units: Unlimited <%= input[:unit_measure] %>\n": trial_license_selection
       "3. Commercial License\n": commercial_license_selection
       "4. Quit license generation": exit
 
@@ -303,12 +303,12 @@ interactions:
     paths: [free_license_selection]
 
   free_license_selection:
-    messages: "Type: Free License\n  Validity: Unlimited\n  No. of targets: 10\n"
+    messages: "Type: Free License\n  Validity: Unlimited\n  No. of units: 10 <%= input[:unit_measure] %>\n"
     prompt_type: "silent"
     paths: [check_if_user_details_are_present]
 
   trial_license_selection:
-    messages: "Type: Trial License\n  Validity: 30 days\n  No. of targets: Unlimited\n"
+    messages: "Type: Trial License\n  Validity: 30 days\n  No. of units: Unlimited <%= input[:unit_measure] %>\n"
     prompt_type: "silent"
     paths: [check_if_user_details_are_present]
 

--- a/components/ruby/spec/chef_licensing_ux_spec.rb
+++ b/components/ruby/spec/chef_licensing_ux_spec.rb
@@ -37,6 +37,13 @@ RSpec.describe ChefLicensing::TUIEngine do
     }
   }
 
+  let(:additional_info_for_tui_engine) {
+    {
+      chef_product_name: ChefLicensing::Config.chef_product_name&.capitalize,
+      unit_measure: "targets",
+    }
+  }
+
   let(:free_license_generation_success_response) {
     {
       "delivery": "RealTime",
@@ -285,6 +292,7 @@ RSpec.describe ChefLicensing::TUIEngine do
     }
 
     it "generates the license successfully traversing through the interactions in expected order" do
+      expect { tui_engine.append_info_to_input(additional_info_for_tui_engine) }.to_not raise_error
       expect { tui_engine.run_interaction(start_interaction) }.to_not raise_error
       expect(tui_engine.traversed_interaction).to eq(expected_flow_for_license_generation)
       expect(prompt.output.string).to include("I don't have a license ID and would like to generate a new license ID")
@@ -484,12 +492,13 @@ RSpec.describe ChefLicensing::TUIEngine do
     }
 
     it "generates the license successfully traversing through the interactions in expected order" do
+      expect { tui_engine.append_info_to_input(additional_info_for_tui_engine) }.to_not raise_error
       expect { tui_engine.run_interaction(start_interaction) }.to_not raise_error
       expect(tui_engine.traversed_interaction).to eq(expected_flow_for_license_generation)
       expect(prompt.output.string).to include("I don't have a license ID and would like to generate a new license ID")
       expect(prompt.output.string).to include("Select the type of license below and then enter user details")
       expect(prompt.output.string).to include("2. Trial License")
-      expect(prompt.output.string).to include("No. of targets: Unlimited")
+      expect(prompt.output.string).to include("No. of units: Unlimited targets")
       expect(prompt.output.string).to include("Please enter the following details:\nFirst Name, Last Name, Email, Company, Phone")
       expect(prompt.output.string).to include("The license ID has been sent to johndoe@chef.com")
     end
@@ -693,12 +702,13 @@ RSpec.describe ChefLicensing::TUIEngine do
     }
 
     it "generates the license successfully traversing through the interactions in expected order" do
+      expect { tui_engine.append_info_to_input(additional_info_for_tui_engine) }.to_not raise_error
       expect { tui_engine.run_interaction(start_interaction) }.to_not raise_error
       expect(tui_engine.traversed_interaction).to eq(expected_flow_for_license_generation)
       expect(prompt.output.string).to include("I don't have a license ID and would like to generate a new license ID")
       expect(prompt.output.string).to include("Select the type of license below and then enter user details")
       expect(prompt.output.string).to include("2. Trial License")
-      expect(prompt.output.string).to include("No. of targets: Unlimited")
+      expect(prompt.output.string).to include("No. of units: Unlimited targets")
       expect(prompt.output.string).to include("Please enter the following details:\nFirst Name, Last Name, Email, Company, Phone")
       expect(prompt.output.string).to include("The license ID has been sent to johndoe@chef.com")
     end
@@ -710,6 +720,7 @@ RSpec.describe ChefLicensing::TUIEngine do
     let(:tui_engine) { described_class.new(opts) }
 
     it "shows the error message for expired license" do
+      expect { tui_engine.append_info_to_input(additional_info_for_tui_engine) }.to_not raise_error
       expect { tui_engine.run_interaction(start_interaction) }.to_not raise_error
       expect(tui_engine.traversed_interaction).to eq(%i{prompt_license_expired fetch_license_id})
       expect(prompt.output.string).to include("License Expired")
@@ -726,6 +737,7 @@ RSpec.describe ChefLicensing::TUIEngine do
     let(:tui_engine) { described_class.new(opts) }
 
     it "shows the error message for expired license" do
+      expect { tui_engine.append_info_to_input(additional_info_for_tui_engine) }.to_not raise_error
       expect { tui_engine.run_interaction(start_interaction) }.to_not raise_error
       expect(tui_engine.traversed_interaction).to eq(%i{prompt_license_expired_local_mode fetch_license_id})
       expect(prompt.output.string).to include("License Expired")


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This PR introduces the change in the UI text to display unit measure as target or node depending upon the product name.

## Related Issue
**CHEF-3768: Display Target or Node as the unit measure depending upon the Chef Product (UI/UX Change)**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
