### PR TITLE
Improve TUI Engine's error message to debug broken flows

### DIFF
--- a/components/ruby/lib/chef-licensing/tui_engine/tui_engine.rb
+++ b/components/ruby/lib/chef-licensing/tui_engine/tui_engine.rb
@@ -25,14 +25,18 @@ module ChefLicensing
       start_interaction_id ||= @tui_interactions.keys.first
       current_interaction = @tui_interactions[start_interaction_id]
 
+      previous_interaction = nil
+
       until current_interaction.nil? || current_interaction.id == :exit
         @traversed_interaction << current_interaction.id
         state.default_action(current_interaction)
+        previous_interaction = current_interaction
         current_interaction = state.next_interaction_id.nil? ? nil : current_interaction.paths[state.next_interaction_id.to_sym]
       end
 
       # If the last interaction is not the exit interaction. Something went wrong in the flow.
-      raise ChefLicensing::TUIEngine::IncompleteFlowException, "Something went wrong in the flow." unless current_interaction&.id == :exit
+      # raise the message where the flow broke.
+      raise ChefLicensing::TUIEngine::IncompleteFlowException, "Something went wrong in the flow. The last interaction was #{previous_interaction&.id}." unless current_interaction&.id == :exit
 
       state.default_action(current_interaction)
       # remove the pastel key we used in tui engine state for styling and return the remaining parsed input

--- a/components/ruby/spec/chef-licensing/tui_engine/tui_engine_spec.rb
+++ b/components/ruby/spec/chef-licensing/tui_engine/tui_engine_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe ChefLicensing::TUIEngine do
       let(:tui_engine) { described_class.new(config) }
 
       it "should raise exception of incomplete path" do
-        expect { tui_engine.run_interaction }.to raise_error(ChefLicensing::TUIEngine::IncompleteFlowException, /Something went wrong in the flow./)
+        expect { tui_engine.run_interaction }.to raise_error(ChefLicensing::TUIEngine::IncompleteFlowException, /Something went wrong in the flow. The last interaction was start/)
       end
     end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This error message is helpful to developers working on chef-licensing and this flow is not expected to break for the users of chef-licensing gem.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
