### PR TITLE
CHEF-3829: Clarify error message when license server is unreachable

### DIFF
--- a/components/ruby/lib/chef-licensing/restful_client/middleware/exceptions_handler.rb
+++ b/components/ruby/lib/chef-licensing/restful_client/middleware/exceptions_handler.rb
@@ -8,7 +8,9 @@ module Middleware
     def call(env)
       @app.call(env)
     rescue Faraday::ConnectionFailed => e
-      raise ChefLicensing::RestfulClientConnectionError, e.message
+      ChefLicensing::Config.logger.debug("Connection failed to #{ChefLicensing::Config.license_server_url} with error: #{e.message}")
+      error_message = "Unable to connect to the licensing server at #{ChefLicensing::Config.license_server_url}.\nPlease check if the server is reachable and try again. #{ChefLicensing::Config.chef_product_name} requires server communication to operate."
+      raise ChefLicensing::RestfulClientConnectionError, error_message
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This PR updates the error message when license server is unreachable. 
- The original error message was 
   ```
   [2023-06-28T08:12:18+05:30] ERROR: Failed to open TCP connection to sonusaha.chef.co:443 (getaddrinfo: nodename nor servname provided, or not known)
   ```

- It is updated to
  ```
  [2023-06-28T12:17:35+05:30] ERROR: Unable to connect to the licensing server at https://dummy-licesning.chef.co/License.
  Please check if the server is reachable and try again. Inspec requires server communication to operate.
  ```

This PR provides a quick fix to improve the error message. It doesn't address the support for multiple license server URLs, which will be addressed in PR #145 if required

## Related Issue
**CHEF-3829: Clarify error message when license server is unreachable**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
