### PR TITLE
CHEF-4087: Feature support multiple license server URLs 

### DIFF
--- a/components/ruby/lib/chef-licensing/restful_client/base.rb
+++ b/components/ruby/lib/chef-licensing/restful_client/base.rb
@@ -93,7 +93,7 @@ module ChefLicensing
         # Note: Current limit is set to 5 attempts for trying to connect to the server
         n = urls.size > 5 ? 5 : urls.size
         n.times do |i|
-          url = urls[i]
+          url = urls[i].strip
           logger.debug "Trying to connect to #{url}"
           handle_connection.call(url) do |connection|
             response = connection.send(http_method, endpoint) do |request|

--- a/components/ruby/lib/chef-licensing/restful_client/base.rb
+++ b/components/ruby/lib/chef-licensing/restful_client/base.rb
@@ -90,7 +90,7 @@ module ChefLicensing
       def invoke_api(urls, endpoint, http_method, payload = nil, params = {}, headers = {})
         handle_connection = http_method == :get ? method(:handle_get_connection) : method(:handle_post_connection)
         response = nil
-        # Note: Current limit is set to 5 attempts for trying to connect to the server
+        # Note: Limiting the number of retries for different urls to 5 or less (if there are less than 5 urls)
         n = urls.size > 5 ? 5 : urls.size
         n.times do |i|
           url = urls[i].strip
@@ -102,7 +102,8 @@ module ChefLicensing
               request.headers = headers if headers
             end
           end
-          # Update the value of license server url in config if there are multiple urls
+          # At this point, we have a successful connection
+          # Update the value of license server url in config if there are multiple urls and break the loop
           ChefLicensing::Config.license_server_url = url if urls.size > 1
           logger.debug "Connection succeeded to #{url}"
           break response

--- a/components/ruby/lib/chef-licensing/restful_client/base.rb
+++ b/components/ruby/lib/chef-licensing/restful_client/base.rb
@@ -108,6 +108,8 @@ module ChefLicensing
           break response
         rescue RestfulClientConnectionError
           logger.warn "Connection failed to #{url}"
+        rescue URI::InvalidURIError
+          logger.warn "Invalid URI #{url}"
         end
 
         raise_restful_client_conn_error(urls) if response.nil?

--- a/components/ruby/lib/chef-licensing/restful_client/base.rb
+++ b/components/ruby/lib/chef-licensing/restful_client/base.rb
@@ -89,16 +89,7 @@ module ChefLicensing
           logger.debug "Connection failed to #{url} with error: #{e.message}"
         end
 
-        error_message = <<~EOM
-          Unable to connect to the licensing server. #{ChefLicensing::Config.chef_product_name} requires server communication to operate.
-          The following URL(s) were tried:\n#{
-            urls.each_with_index.map do |url, index|
-              "#{index + 1}. #{url}"
-            end.join("\n")
-          }
-        EOM
-        raise RestfulClientConnectionError, error_message if response.nil?
-
+        raise_restful_client_conn_error(urls) if response.nil?
         response.body
       end
 
@@ -121,16 +112,7 @@ module ChefLicensing
           logger.debug "Connection failed to #{url} with error: #{e.message}"
         end
 
-        error_message = <<~EOM
-          Unable to connect to the licensing server. #{ChefLicensing::Config.chef_product_name} requires server communication to operate.
-          The following URL(s) were tried:\n#{
-            urls.each_with_index.map do |url, index|
-              "#{index + 1}. #{url}"
-            end.join("\n")
-          }
-        EOM
-
-        raise RestfulClientConnectionError, error_message if response.nil?
+        raise_restful_client_conn_error(urls) if response.nil?
 
         raise RestfulClientError, format_error_from(response) unless response.success?
 
@@ -177,6 +159,19 @@ module ChefLicensing
         return response.reason_phrase unless error_details
 
         error_details
+      end
+
+      def raise_restful_client_conn_error(urls)
+        error_message = <<~EOM
+          Unable to connect to the licensing server. #{ChefLicensing::Config.chef_product_name} requires server communication to operate.
+          The following URL(s) were tried:\n#{
+            urls.each_with_index.map do |url, index|
+              "#{index + 1}. #{url}"
+            end.join("\n")
+          }
+        EOM
+
+        raise RestfulClientConnectionError, error_message
       end
     end
   end

--- a/components/ruby/lib/chef-licensing/restful_client/middleware/exceptions_handler.rb
+++ b/components/ruby/lib/chef-licensing/restful_client/middleware/exceptions_handler.rb
@@ -8,9 +8,7 @@ module Middleware
     def call(env)
       @app.call(env)
     rescue Faraday::ConnectionFailed => e
-      ChefLicensing::Config.logger.debug("Connection failed to #{ChefLicensing::Config.license_server_url} with error: #{e.message}")
-      error_message = "Unable to connect to the licensing server at #{ChefLicensing::Config.license_server_url}.\nPlease check if the server is reachable and try again. #{ChefLicensing::Config.chef_product_name} requires server communication to operate."
-      raise ChefLicensing::RestfulClientConnectionError, error_message
+      raise ChefLicensing::RestfulClientConnectionError, e.message
     end
   end
 end

--- a/components/ruby/spec/restful_client_v1_spec.rb
+++ b/components/ruby/spec/restful_client_v1_spec.rb
@@ -164,6 +164,7 @@ RSpec.describe ChefLicensing::RestfulClient::V1 do
 
     it "breaks after 5th attempt and raises an error" do
       expect { base_obj.validate(free_license_key) }.to raise_error(ChefLicensing::RestfulClientConnectionError, /Unable to connect to the licensing server. inspec requires server communication to operate/ )
+      expect(output.string).to include("Only the first 5 urls will be tried")
       expect(output.string).to include("Connection failed to http://localhost-2-license-server/License")
     end
   end

--- a/components/ruby/spec/restful_client_v1_spec.rb
+++ b/components/ruby/spec/restful_client_v1_spec.rb
@@ -1,0 +1,69 @@
+require "spec_helper"
+require "chef-licensing/config"
+require "chef-licensing/restful_client/v1"
+
+RSpec.describe ChefLicensing::RestfulClient::V1 do
+  let(:output) { StringIO.new }
+  let(:logger) { Logger.new(output) }
+  let(:free_license_key) { "free-c0832d2d-1111-1ec1-b1e5-011d182dc341-111" }
+
+  context "when one license_server_url is set" do
+    before do
+      ChefLicensing.configure do |config|
+        config.logger = logger
+        config.output = output
+        config.license_server_url = "http://globalhost-license-server/License"
+        config.license_server_url_check_in_file = true
+        config.chef_product_name = "inspec"
+        config.chef_entitlement_id = "3ff52c37-e41f-4f6c-ad4d-365192205968"
+      end
+    end
+
+    before do
+      stub_request(:get, "#{ChefLicensing::Config.license_server_url}/v1/validate")
+        .with(query: { licenseId: free_license_key, version: 2 })
+        .to_return(body: { data: true, message: "License Id is valid", status_code: 200 }.to_json,
+                  headers: { content_type: "application/json" })
+    end
+
+    let(:base_obj) { described_class.new }
+
+    it "invokes the endpoint with the specified license_server_url" do
+      expect(base_obj.validate(free_license_key).data).to eq(true)
+    end
+  end
+
+  context "when multiple license_server_url is set" do
+    before do
+      ChefLicensing.configure do |config|
+        config.logger = logger
+        config.output = output
+        config.license_server_url = "http://localhost-1-license-server/License,http://localhost-2-license-server/License"
+        config.license_server_url_check_in_file = true
+        config.chef_product_name = "inspec"
+        config.chef_entitlement_id = "3ff52c37-e41f-4f6c-ad4d-365192205968"
+      end
+    end
+
+    before do
+      # stub the first url to be unreachable
+      stub_request(:get, "http://localhost-1-license-server/License/v1/validate")
+        .with(query: { licenseId: free_license_key, version: 2 })
+        .to_raise(Errno::ECONNREFUSED)
+
+      stub_request(:get, "http://localhost-2-license-server/License/v1/validate")
+        .with(query: { licenseId: free_license_key, version: 2 })
+        .to_return(body: { data: true, message: "License Id is valid", status_code: 200 }.to_json,
+                  headers: { content_type: "application/json" })
+    end
+
+    let(:base_obj) { described_class.new }
+
+    it "finds a URL which is reachable and invokes the endpoint with that URL" do
+      expect(base_obj.validate(free_license_key).data).to eq(true)
+      expect(output.string).to include("Connection failed to http://localhost-1-license-server/License with error")
+      # it updates the config with the reachable URL
+      expect(ChefLicensing::Config.license_server_url).to eq("http://localhost-2-license-server/License")
+    end
+  end
+end

--- a/components/ruby/spec/restful_client_v1_spec.rb
+++ b/components/ruby/spec/restful_client_v1_spec.rb
@@ -102,4 +102,39 @@ RSpec.describe ChefLicensing::RestfulClient::V1 do
       expect(ChefLicensing::Config.license_server_url).to eq("http://localhost-2-license-server/License")
     end
   end
+
+  context "when bad license_server_url is set in config with comma" do
+    before do
+      ChefLicensing.configure do |config|
+        config.logger = logger
+        config.output = output
+        config.license_server_url = "http://www.exa-mple.com?catid=123&prodid=456!@#$%^&*, http://localhost-2-license-server/License"
+        config.license_server_url_check_in_file = true
+        config.chef_product_name = "inspec"
+        config.chef_entitlement_id = "3ff52c37-e41f-4f6c-ad4d-365192205968"
+      end
+    end
+
+    before do
+      # stub the first url to be unreachable
+      stub_request(:get, "http://localhost-1-license-server/License/v1/validate")
+        .with(query: { licenseId: free_license_key, version: 2 })
+        .to_raise(URI::InvalidURIError)
+
+      stub_request(:get, "http://localhost-2-license-server/License/v1/validate")
+        .with(query: { licenseId: free_license_key, version: 2 })
+        .to_return(body: { data: true, message: "License Id is valid", status_code: 200 }.to_json,
+                  headers: { content_type: "application/json" })
+    end
+
+    let(:base_obj) { described_class.new }
+
+    it "finds a URL which is reachable and invokes the endpoint with that URL" do
+      expect(base_obj.validate(free_license_key).data).to eq(true)
+      expect(output.string).to include("Connection succeeded to http://localhost-2-license-server/License")
+      expect(output.string).to include("Invalid URI http://www.exa-mple.com?catid=123&prodid=456!@#$%^&*")
+      # it updates the config with the reachable URL
+      expect(ChefLicensing::Config.license_server_url).to eq("http://localhost-2-license-server/License")
+    end
+  end
 end

--- a/components/ruby/spec/restful_client_v1_spec.rb
+++ b/components/ruby/spec/restful_client_v1_spec.rb
@@ -67,4 +67,39 @@ RSpec.describe ChefLicensing::RestfulClient::V1 do
       expect(ChefLicensing::Config.license_server_url).to eq("http://localhost-2-license-server/License")
     end
   end
+
+  context "when multiple license_server_url is set in config with space after comma" do
+    before do
+      ChefLicensing.configure do |config|
+        config.logger = logger
+        config.output = output
+        config.license_server_url = "http://localhost-1-license-server/License, http://localhost-2-license-server/License"
+        config.license_server_url_check_in_file = true
+        config.chef_product_name = "inspec"
+        config.chef_entitlement_id = "3ff52c37-e41f-4f6c-ad4d-365192205968"
+      end
+    end
+
+    before do
+      # stub the first url to be unreachable
+      stub_request(:get, "http://localhost-1-license-server/License/v1/validate")
+        .with(query: { licenseId: free_license_key, version: 2 })
+        .to_raise(Errno::ECONNREFUSED)
+
+      stub_request(:get, "http://localhost-2-license-server/License/v1/validate")
+        .with(query: { licenseId: free_license_key, version: 2 })
+        .to_return(body: { data: true, message: "License Id is valid", status_code: 200 }.to_json,
+                  headers: { content_type: "application/json" })
+    end
+
+    let(:base_obj) { described_class.new }
+
+    it "finds a URL which is reachable and invokes the endpoint with that URL" do
+      expect(base_obj.validate(free_license_key).data).to eq(true)
+      expect(output.string).to include("Connection succeeded to http://localhost-2-license-server/License")
+      expect(output.string).to include("Connection failed to http://localhost-1-license-server/License")
+      # it updates the config with the reachable URL
+      expect(ChefLicensing::Config.license_server_url).to eq("http://localhost-2-license-server/License")
+    end
+  end
 end

--- a/components/ruby/spec/restful_client_v1_spec.rb
+++ b/components/ruby/spec/restful_client_v1_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe ChefLicensing::RestfulClient::V1 do
 
     it "finds a URL which is reachable and invokes the endpoint with that URL" do
       expect(base_obj.validate(free_license_key).data).to eq(true)
-      expect(output.string).to include("Connection failed to http://localhost-1-license-server/License with error")
+      expect(output.string).to include("Connection succeeded to http://localhost-2-license-server/License")
+      expect(output.string).to include("Connection failed to http://localhost-1-license-server/License")
       # it updates the config with the reachable URL
       expect(ChefLicensing::Config.license_server_url).to eq("http://localhost-2-license-server/License")
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This PR adds support for using multiple license server URLs. The implementation works by trying each URL until a reachable server URL is found. The reachable URL is then updated in the Config to be used for the duration of the program's execution.

To specify the multiple license server URLs, you can either provide them as comma-separated values using an argument or set them as environment variables.

Example: 
`export CHEF_LICENSE_SERVER=http://localhost-1-license-server/License,http://localhost-2-license-server/License`
or
`--chef-license-server=http://localhost-1-license-server/License,http://localhost-2-license-server/License`

## Related Issue
**CHEF-4087: Support multiple license server URL in chef licensing**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
