### PR TITLE
Set License ID string in gemspec to select LICENSE file

### DIFF
--- a/components/ruby/chef-licensing.gemspec
+++ b/components/ruby/chef-licensing.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.version       = ChefLicensing::VERSION
   spec.authors       = ["Inspec Team"]
   spec.email         = ["inspec@progress.com"]
-  spec.license       = "Proprietary"
+  spec.license       = "LicenseRef-LICENSE"
 
   spec.summary       = %q{Chef License storage, generation, and entitlement}
   spec.description   = %q{Ruby library to support CLI tools that use Progress Chef license storage, generation, and entitlement.}


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Set License ID string in gemspec to select LICENSE file

This doesn't change the LICENSE - which remains Proprietary at this time - but it does correct the gem build, so that the gem build system properly can find the custom license file.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
