### PR TITLE
CHEF-3843: Update exception class for invalid file format version of licenses.yaml

### DIFF
--- a/components/ruby/lib/chef-licensing/exceptions/invalid_file_format_version.rb
+++ b/components/ruby/lib/chef-licensing/exceptions/invalid_file_format_version.rb
@@ -1,0 +1,10 @@
+require_relative "error"
+
+module ChefLicensing
+  class InvalidFileFormatVersion < Error
+    def message
+      super || "Invalid File Format Version"
+    end
+  end
+end
+

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/file.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/file.rb
@@ -5,6 +5,7 @@ require "date"
 require "fileutils" unless defined?(FileUtils)
 require_relative "../license_key_fetcher"
 require_relative "../config"
+require_relative "../exceptions/invalid_file_format_version"
 
 module ChefLicensing
   class LicenseKeyFetcher
@@ -211,7 +212,7 @@ module ChefLicensing
           @contents
         else
           logger.debug "License File version #{@contents[:file_format_version]} not supported."
-          raise LicenseKeyNotFetchedError.new("License File version #{@contents[:file_format_version]} not supported.")
+          raise ChefLicensing::InvalidFileFormatVersion.new("Unable to read licenses. License File version #{@contents[:file_format_version]} not supported.")
         end
       end
 

--- a/components/ruby/spec/chef-licensing/license_key_fetcher/file_spec.rb
+++ b/components/ruby/spec/chef-licensing/license_key_fetcher/file_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ChefLicensing::LicenseKeyFetcher::File do
     it "raises error for unsupported version of license file with wrong version" do
       Dir.mktmpdir do |tmpdir|
         file_fetcher = ChefLicensing::LicenseKeyFetcher::File.new({ dir: unsupported_vesion_license_dir })
-        expect { file_fetcher.fetch }.to raise_error(RuntimeError, /License File version 0.0.0 not supported./)
+        expect { file_fetcher.fetch }.to raise_error(ChefLicensing::InvalidFileFormatVersion, /License File version 0.0.0 not supported./)
       end
     end
 

--- a/components/ruby/spec/list_license_keys_spec.rb
+++ b/components/ruby/spec/list_license_keys_spec.rb
@@ -97,8 +97,7 @@ RSpec.describe ChefLicensing::ListLicenseKeys do
     end
 
     it "exits with error message about LicenseKeyNotFetchedError" do
-      expect { described_class.new(opts_for_llk).display }.to raise_error(SystemExit)
-      expect(output_stream.string).to include("Error occured while fetching license keys from disk")
+      expect { described_class.new(opts_for_llk).display }.to raise_error(ChefLicensing::InvalidFileFormatVersion, /License File version 0.0.0 not supported./)
     end
   end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR introduces the change to raise a new exception class viz. `InvalidFileFormatVersion` when an unsupported licenses.yaml is present in the system. It helps the application using the chef-licensing library to raise appropriate error message.

Given a system has the following licenses.yaml file
```
❯ cat ~/.chef/licenses.yaml
---
:file_format_version: 3.0.0
:license_server_url: https://licensing-acceptance.chef.co/License
:licenses:
- :license_key: free-00000000-111b-4cb2-a7f3-ab2222d025d7-999
  :license_type: :free
  :update_time: '2023-07-10T15:08:25+05:30'
```
The current behavior of InSpec with an unsupported licenses.yaml on the system is as below:
```
❯ bundle exec inspec exec
[2023-07-10T15:08:44+05:30] ERROR: Chef InSpec cannot execute without valid licenses.
```

The behavior of InSpec with the changes from this PR:
```
❯ bundle exec inspec exec
[2023-07-10T15:08:56+05:30] ERROR: Unable to read licenses. License File version 3.0.0 not supported.
```

## Related Issue
**CHEF-3843: InSpec throws unclear error on licenses.yaml version mismatch**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
