### PR TITLE
CHEF-3841: Handle different versions of `licenses.yaml` file [Backward Compatibility Support]

### DIFF
--- a/components/ruby/lib/chef-licensing/exceptions/license_file_corrupted.rb
+++ b/components/ruby/lib/chef-licensing/exceptions/license_file_corrupted.rb
@@ -1,0 +1,9 @@
+require_relative "error"
+
+module ChefLicensing
+  class LicenseFileCorrupted < Error
+    def message
+      super || "License file contents are corrupted"
+    end
+  end
+end

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/file.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/file.rb
@@ -221,6 +221,7 @@ module ChefLicensing
         # 3. If the file format version is different and not supported, raise an error.
         if major_version(@contents[:file_format_version]) == major_version(LICENSE_FILE_FORMAT_VERSION)
           current_version_class_name = get_license_file_class(LICENSE_FILE_FORMAT_VERSION)
+          # we ignore any additional keys in the license file during verification
           raise LicenseFileCorrupted.new("Invalid data found in the license file.") unless current_version_class_name.send(:verify_structure, @contents)
 
           @contents
@@ -310,6 +311,7 @@ module ChefLicensing
         logger.warn "License File version #{contents[:file_format_version]} is deprecated."
         logger.warn "Automatically migrating license file to version #{LICENSE_FILE_FORMAT_VERSION}."
         given_version_class_name = get_license_file_class(contents[:file_format_version])
+        # we ignore any additional keys in the license file during verification
         raise LicenseFileCorrupted.new("Invalid data found in the license file.") unless given_version_class_name.send(:verify_structure, contents)
 
         current_version_class_name = get_license_file_class(LICENSE_FILE_FORMAT_VERSION)

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/file.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/file.rb
@@ -212,6 +212,9 @@ module ChefLicensing
         # only checking for major version for file format for breaking changes
         @contents ||= YAML.load(::File.read(path))
 
+        # raise error if the file_format_version key is missing
+        raise LicenseFileCorrupted.new("Unrecognized license file; :file_format_version missing.") unless @contents.key?(:file_format_version)
+
         # Three possible cases after loading the license file contents:
         # 1. If the file format version is the same as the current version (latest), verify the structure and return the contents.
         # 2. If the file format version is different but supported, migrate the contents to the current version and return them.

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/file.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/file.rb
@@ -5,6 +5,9 @@ require "date"
 require "fileutils" unless defined?(FileUtils)
 require_relative "../license_key_fetcher"
 require_relative "../config"
+require_relative "../exceptions/license_file_corrupted"
+require_relative "license_file/v4"
+require_relative "license_file/v3"
 require_relative "../exceptions/invalid_file_format_version"
 
 module ChefLicensing
@@ -119,15 +122,15 @@ module ChefLicensing
 
         @contents = load_license_file(license_key_file_path)
 
+        # Two possible cases:
+        # 1. If contents is nil, load basic license data with the latest structure.
+        # 2. If contents is not nil, but the license server URL in contents is different from the system's,
+        #    update the license server URL in contents and licenses.yaml file.
         if @contents.nil?
-          @contents = {
-            file_format_version: LICENSE_FILE_FORMAT_VERSION,
-            license_server_url: license_server_url_from_system || license_server_url_from_config,
-          }
-        else
-          if license_server_url_from_system && license_server_url_from_system != @contents[:license_server_url]
-            @contents[:license_server_url] = license_server_url_from_system
-          end
+          url = license_server_url_from_system || license_server_url_from_config
+          load_basic_license_data_to_contents(url, [])
+        elsif @contents && license_server_url_from_system && license_server_url_from_system != @contents[:license_server_url]
+          @contents[:license_server_url] = license_server_url_from_system
         end
 
         # Ensure the license server URL is returned to the caller in all cases
@@ -208,7 +211,19 @@ module ChefLicensing
 
         # only checking for major version for file format for breaking changes
         @contents ||= YAML.load(::File.read(path))
+
+        # Three possible cases after loading the license file contents:
+        # 1. If the file format version is the same as the current version (latest), verify the structure and return the contents.
+        # 2. If the file format version is different but supported, migrate the contents to the current version and return them.
+        # 3. If the file format version is different and not supported, raise an error.
         if major_version(@contents[:file_format_version]) == major_version(LICENSE_FILE_FORMAT_VERSION)
+          current_version_class_name = get_license_file_class(LICENSE_FILE_FORMAT_VERSION)
+          raise LicenseFileCorrupted.new("Invalid data found in the license file.") unless current_version_class_name.send(:verify_structure, @contents)
+
+          @contents
+        elsif license_file_class_exists?(@contents[:file_format_version])
+          @contents = migrate_license_file_content_to_current_version(@contents)
+          write_license_file(path) # update the license file contents to the latest version
           @contents
         else
           logger.debug "License File version #{@contents[:file_format_version]} not supported."
@@ -245,11 +260,7 @@ module ChefLicensing
 
         logger.debug "Loading license data to contents"
         if @contents.nil? || @contents.empty? # this case is likely to happen only during testing
-          @contents = {
-            file_format_version: LICENSE_FILE_FORMAT_VERSION,
-            license_server_url: @license_server_url,
-            licenses: [license_data],
-          }
+          load_basic_license_data_to_contents(@license_server_url, [license_data])
         elsif @contents[:licenses].nil?
           @contents[:licenses] = [license_data]
         elsif fetch_license_keys(@contents[:licenses])&.include?(license_data[:license_key])
@@ -270,6 +281,37 @@ module ChefLicensing
       def handle_error(e, message = nil)
         logger.debug "#{e.backtrace.join("\n\t")}"
         e
+      end
+
+      # Returns the license file class for the given version.
+      def get_license_file_class(version)
+        Object.const_get("ChefLicensing::LicenseFile::V#{major_version(version)}")
+      end
+
+      # Returns true if the license file class for the given version exists.
+      def license_file_class_exists?(version)
+        Object.const_defined?("ChefLicensing::LicenseFile::V#{major_version(version)}")
+      end
+
+      # Loads the basic license data to contents in the current version's structure.
+      def load_basic_license_data_to_contents(url, license_data = [])
+        current_version_class_name = get_license_file_class(LICENSE_FILE_FORMAT_VERSION)
+        @contents = current_version_class_name.send(:load_primary_structure)
+        @contents[:file_format_version] = LICENSE_FILE_FORMAT_VERSION
+        @contents[:license_server_url] = url || ""
+        @contents[:licenses] = license_data
+      end
+
+      # Migrates the license file content to the current version and returns the migrated contents.
+      def migrate_license_file_content_to_current_version(contents)
+        logger.warn "License File version #{contents[:file_format_version]} is deprecated."
+        logger.warn "Automatically migrating license file to version #{LICENSE_FILE_FORMAT_VERSION}."
+        given_version_class_name = get_license_file_class(contents[:file_format_version])
+        raise LicenseFileCorrupted.new("Invalid data found in the license file.") unless given_version_class_name.send(:verify_structure, contents)
+
+        current_version_class_name = get_license_file_class(LICENSE_FILE_FORMAT_VERSION)
+        contents = current_version_class_name.send(:migrate_structure, contents, major_version(contents[:file_format_version]))
+        contents
       end
     end
   end

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/license_file/base.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/license_file/base.rb
@@ -12,6 +12,9 @@ module ChefLicensing
         ],
       }.freeze
 
+      # @param [Hash] data: The data to verify
+      # @param [Hash] expected_structure: The structure to verify against
+      # @return [Boolean] true if the data matches the expected structure, false otherwise
       def self.verify_structure(data, expected_structure = self::EXPECTED_STRUCTURE)
         return false unless data.is_a?(Hash)
 
@@ -36,16 +39,21 @@ module ChefLicensing
         true
       end
 
+      # @return [Hash] The primary structure of the license file, without nested structures
       def self.load_primary_structure
         expected_structure_dup = self::EXPECTED_STRUCTURE.dup
         expected_structure_dup[:licenses] = []
         expected_structure_dup
       end
 
+      # @return [Hash] The complete structure of the license file, including nested structures
       def self.load_structure
         self::EXPECTED_STRUCTURE
       end
 
+      # @param [Hash] contents: The contents of the license file
+      # @param [Integer] version: The version of the license file
+      # @return [Hash] The contents of the license file after migration
       def self.migrate_structure(contents, version)
         raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
       end

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/license_file/base.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/license_file/base.rb
@@ -15,6 +15,7 @@ module ChefLicensing
       # @param [Hash] data: The data to verify
       # @param [Hash] expected_structure: The structure to verify against
       # @return [Boolean] true if the data matches the expected structure, false otherwise
+      # @note This method ignores extra keys in the data that are not in the expected structure
       def self.verify_structure(data, expected_structure = self::EXPECTED_STRUCTURE)
         return false unless data.is_a?(Hash)
 

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/license_file/base.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/license_file/base.rb
@@ -1,0 +1,54 @@
+module ChefLicensing
+  module LicenseFile
+    class Base
+      EXPECTED_STRUCTURE = {
+        file_format_version: "0.0.0",
+        licenses: [
+          {
+            license_key: String,
+            license_type: Symbol,
+            update_time: String,
+          },
+        ],
+      }.freeze
+
+      def self.verify_structure(data, expected_structure = self::EXPECTED_STRUCTURE)
+        return false unless data.is_a?(Hash)
+
+        expected_structure.each do |key, value|
+          return false unless data.key?(key)
+
+          if value.is_a?(Hash)
+            return false unless verify_structure(data[key], value)
+          elsif value.is_a?(Array)
+            return false unless data[key].is_a?(Array)
+
+            data[key].each do |item|
+              return false unless verify_structure(item, value[0])
+            end
+          elsif value.is_a?(Class)
+            return false unless data[key].is_a?(value)
+          else
+            return false unless data[key] == value
+          end
+        end
+
+        true
+      end
+
+      def self.load_primary_structure
+        expected_structure_dup = self::EXPECTED_STRUCTURE.dup
+        expected_structure_dup[:licenses] = []
+        expected_structure_dup
+      end
+
+      def self.load_structure
+        self::EXPECTED_STRUCTURE
+      end
+
+      def self.migrate_structure(contents, version)
+        raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+      end
+    end
+  end
+end

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/license_file/v3.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/license_file/v3.rb
@@ -1,0 +1,12 @@
+require_relative "base"
+
+module ChefLicensing
+  module LicenseFile
+    class V3 < Base
+      LICENSE_FILE_FORMAT_VERSION = "3.0.0".freeze
+      EXPECTED_STRUCTURE = EXPECTED_STRUCTURE.merge({
+        file_format_version: V3::LICENSE_FILE_FORMAT_VERSION,
+      }).freeze
+    end
+  end
+end

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/license_file/v4.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/license_file/v4.rb
@@ -1,0 +1,24 @@
+require_relative "base"
+require_relative "../../config"
+
+module ChefLicensing
+  module LicenseFile
+    class V4 < Base
+      LICENSE_FILE_FORMAT_VERSION = "4.0.0".freeze
+
+      EXPECTED_STRUCTURE = EXPECTED_STRUCTURE.merge({
+        file_format_version: V4::LICENSE_FILE_FORMAT_VERSION,
+        license_server_url: String,
+      }).freeze
+
+      def self.migrate_structure(contents, version)
+        # Backwards compatibility for version 3 license files
+        if version == 3
+          contents[:license_server_url] = ChefLicensing::Config.license_server_url || ""
+          contents[:file_format_version] = V4::LICENSE_FILE_FORMAT_VERSION
+        end
+        contents
+      end
+    end
+  end
+end

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/license_file/v4.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/license_file/v4.rb
@@ -11,6 +11,9 @@ module ChefLicensing
         license_server_url: String,
       }).freeze
 
+      # @param [Hash] contents: The contents of the license file
+      # @param [Integer] version: The version of the license file
+      # @return [Hash] The contents of the license file after migration
       def self.migrate_structure(contents, version)
         # Backwards compatibility for version 3 license files
         if version == 3

--- a/components/ruby/spec/fixtures/license_file_without_file_format_version/licenses.yaml
+++ b/components/ruby/spec/fixtures/license_file_without_file_format_version/licenses.yaml
@@ -1,0 +1,5 @@
+---
+:licenses:
+- :license_key: free-c0832d2d-1111-1ec1-b1e5-011d182dc341-111
+  :license_type: :free
+  :update_time: '2023-07-18T13:36:22+05:30'

--- a/components/ruby/spec/fixtures/licenses.yaml
+++ b/components/ruby/spec/fixtures/licenses.yaml
@@ -1,6 +1,7 @@
 ---
+:file_format_version: 4.0.0
+:license_server_url: ''
 :licenses:
 - :license_key: 'tmns-0f76efaf-b45b-4d92-86b2-2d144ce73dfa-150'
-  :license_type: trial
+  :license_type: :trial
   :update_time: '2022-09-12T15:29:27+05:30'
-:file_format_version: 4.0.0

--- a/components/ruby/spec/fixtures/multiple_license_keys_license/licenses.yaml
+++ b/components/ruby/spec/fixtures/multiple_license_keys_license/licenses.yaml
@@ -1,9 +1,10 @@
 ---
+:file_format_version: 4.0.0
+:license_server_url: ''
 :licenses:
 - :license_key: 'tmns-0f76efaf-b45b-4d92-86b2-2d144ce73dfa-150'
-  :license_type: trial
+  :license_type: :trial
   :update_time: '2022-10-06T14:22:39+05:30'
 - :license_key: 'free-c0832d2d-1111-1ec1-b1e5-011d182dc341-111'
-  :license_type: free
+  :license_type: :free
   :update_time: '2022-10-06T14:22:48+05:30'
-:file_format_version: 4.0.0

--- a/components/ruby/spec/fixtures/v3_licenses/licenses.yaml
+++ b/components/ruby/spec/fixtures/v3_licenses/licenses.yaml
@@ -1,0 +1,6 @@
+---
+:file_format_version: 3.0.0
+:licenses:
+- :license_key: free-c0832d2d-1111-1ec1-b1e5-011d182dc341-111
+  :license_type: :free
+  :update_time: '2023-07-18T13:36:22+05:30'


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR introduces the backward compatibility handling of version 3.0.0 licenses.yaml files and provides the basic structure of how we would support future versions with minimal changes to the codebase.

## Related Issue
**CHEF-3841: chef-licensing licenses.yaml loading not backward compatible**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
