### PR TITLE
Update regex for company name validation

### DIFF
--- a/components/ruby/lib/chef-licensing/tui_engine/tui_actions.rb
+++ b/components/ruby/lib/chef-licensing/tui_engine/tui_actions.rb
@@ -84,7 +84,12 @@ module ChefLicensing
       end
 
       def is_company_name_valid?(input)
-        (input[:gather_user_company_for_license_generation] =~ /\A[a-zA-Z0-9][a-zA-Z0-9\W_]{2,15}\z/) == 0
+        # Current validation:
+        # The string cannot start with a space.
+        # The string must have a minimum of three characters and a maximum of 20 characters.
+        # The string can contain any combination of characters, including special characters, alphanumeric characters, and spaces.
+        # The string can have additional words separated by spaces, but the total length of the entire cannot exceed 20.
+        (input[:gather_user_company_for_license_generation] =~ /\A(?=.{3,20}\z)(?! )[\w\W]{1,}( [\w\W]+){0,19}\z/) == 0
       end
 
       def is_phone_no_valid?(input)

--- a/components/ruby/spec/chef-licensing/tui_engine/tui_actions_spec.rb
+++ b/components/ruby/spec/chef-licensing/tui_engine/tui_actions_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ChefLicensing::TUIEngine::TUIActions do
     end
 
     unhandled_company_names = [
-      "A  " # 3 characters, but by using space
+      "A  ", # 3 characters, but by using space
     ]
 
     unhandled_company_names.each do |company_name|

--- a/components/ruby/spec/chef-licensing/tui_engine/tui_actions_spec.rb
+++ b/components/ruby/spec/chef-licensing/tui_engine/tui_actions_spec.rb
@@ -9,4 +9,41 @@ RSpec.describe ChefLicensing::TUIEngine::TUIActions do
       expect(tui_actions).to be_a(ChefLicensing::TUIEngine::TUIActions)
     end
   end
+
+  describe "#is_company_name_valid?" do
+    valid_company_names = [
+      "Chef Software",
+      "InSpec",
+      "Progress Softwares",
+      "Company!!!",
+      "Company 123",
+      "Company&Co",
+      "Company_123",
+      "A Company",
+      "A Company 123",
+      "@ Company",
+    ]
+
+    valid_company_names.each do |company_name|
+      it "should return true for valid company name '#{company_name}'" do
+        expect(tui_actions.is_company_name_valid?({ gather_user_company_for_license_generation: company_name })).to be_truthy
+      end
+    end
+
+    invalid_company_names = [
+      "A", # too short
+      "AB", # too short
+      " A ", # leading space
+      " ABC", # leading space
+      "", # empty
+      " ", # empty
+      "A" * 21, # too long, max 20
+    ]
+
+    invalid_company_names.each do |company_name|
+      it "should return false for invalid company name '#{company_name}'" do
+        expect(tui_actions.is_company_name_valid?({ gather_user_company_for_license_generation: company_name })).to be_falsey
+      end
+    end
+  end
 end

--- a/components/ruby/spec/chef-licensing/tui_engine/tui_actions_spec.rb
+++ b/components/ruby/spec/chef-licensing/tui_engine/tui_actions_spec.rb
@@ -45,5 +45,15 @@ RSpec.describe ChefLicensing::TUIEngine::TUIActions do
         expect(tui_actions.is_company_name_valid?({ gather_user_company_for_license_generation: company_name })).to be_falsey
       end
     end
+
+    unhandled_company_names = [
+      "A  " # 3 characters, but by using space
+    ]
+
+    unhandled_company_names.each do |company_name|
+      it "should return false but returns true for unhandled company name '#{company_name}'" do
+        expect(tui_actions.is_company_name_valid?({ gather_user_company_for_license_generation: company_name })).to be_truthy
+      end
+    end
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR updates the regex for the company name validation:
- to accept upto 20 characters length
- to accept space between the company name (two worded company like Progress Chef was not getting accepted)
- to not let the company name start with space

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
