### PR TITLE
Enable caching of license object at the application-level

### DIFF
--- a/components/ruby/lib/chef-licensing/api/client.rb
+++ b/components/ruby/lib/chef-licensing/api/client.rb
@@ -2,6 +2,7 @@ require_relative "../restful_client/v1"
 require_relative "../exceptions/client_error"
 require_relative "../license"
 require_relative "../config"
+require_relative "../restful_client/cache_manager"
 
 module ChefLicensing
   module Api
@@ -17,11 +18,26 @@ module ChefLicensing
       def initialize(opts = {})
         @license_keys = opts[:license_keys] || raise(ArgumentError, "Missing Params: `license_keys`")
         @restful_client = opts[:restful_client] ? opts[:restful_client].new : ChefLicensing::RestfulClient::V1.new
+        @cache_manager = opts[:cache_manager] || ChefLicensing::RestfulClient::CacheManager.new
       end
 
       def info
+        cache_key = license_keys.join(",")
+        @cache_manager.fetch(cache_key) do
+          license = fetch_license
+          @cache_manager.store(cache_key, license, ttl_cache)
+          license
+        end
+      end
+
+      private
+
+      attr_reader :restful_client, :ttl_cache
+
+      def fetch_license
         response = restful_client.client(license_keys: license_keys.join(","), entitlement_id: ChefLicensing::Config.chef_entitlement_id)
         if response.data
+          @ttl_cache = response.data.cache.expires
           ChefLicensing::License.new(
             data: response.data,
             api_parser: ChefLicensing::Api::Parser::Client
@@ -30,10 +46,6 @@ module ChefLicensing
           raise(ChefLicensing::ClientError, response.message)
         end
       end
-
-      private
-
-      attr_reader :restful_client
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR introduces application-level caching of the license objects constructed at the `api/client`'s info method by using the cache manager i.e. `ChefLicensing::RestfulClient::CacheManager`.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
[CHEF-3961: Ability to cache based on per license basis and not at the network level](https://chefio.atlassian.net/browse/CHEF-3961)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
