### PR TITLE
Enable caching of API response at the application-level

### DIFF
--- a/components/ruby/lib/chef-licensing/restful_client/v1.rb
+++ b/components/ruby/lib/chef-licensing/restful_client/v1.rb
@@ -12,6 +12,10 @@ module ChefLicensing
         DESCRIBE: "v1/desc",
         LIST_LICENSES: "v1/listLicenses",
       }).freeze
+
+      CACHE_ENDPOINTS = [
+        END_POINTS[:CLIENT],
+      ].freeze
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR introduces application-level caching of the API responses by using the cache manager i.e. `ChefLicensing::RestfulClient::CacheManager`.

It maintains a list of the endpoints which we would like to cache. The list can be extended or the condition can be removed if we desire to cache for all the endpoints.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
[CHEF-3961: Ability to cache based on per license basis and not at the network level](https://chefio.atlassian.net/browse/CHEF-3961)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
