### PR TITLE
CACHE: Implement the ability to clear the cache by invoking `clear_cache` in base

### DIFF
--- a/components/ruby/lib/chef-licensing.rb
+++ b/components/ruby/lib/chef-licensing.rb
@@ -66,5 +66,9 @@ module ChefLicensing
     def add_license
       ChefLicensing::LicenseKeyFetcher.add_license
     end
+
+    def clear_client_api_cached_response(opts = {})
+      ChefLicensing::Api::Client.clear_client_cache(opts)
+    end
   end
 end

--- a/components/ruby/lib/chef-licensing/api/client.rb
+++ b/components/ruby/lib/chef-licensing/api/client.rb
@@ -12,6 +12,10 @@ module ChefLicensing
         def info(opts = {})
           new(opts).info
         end
+
+        def clear_client_cache(opts = {})
+          new(opts).clear_client_cache
+        end
       end
 
       def initialize(opts = {})
@@ -29,6 +33,10 @@ module ChefLicensing
         else
           raise(ChefLicensing::ClientError, response.message)
         end
+      end
+
+      def clear_client_cache
+        restful_client.clear_cache(ChefLicensing::RestfulClient::V1::END_POINTS[:CLIENT], { licenseId: license_keys.join(","), entitlementId: ChefLicensing::Config.chef_entitlement_id })
       end
 
       private

--- a/components/ruby/lib/chef-licensing/restful_client/base.rb
+++ b/components/ruby/lib/chef-licensing/restful_client/base.rb
@@ -77,6 +77,11 @@ module ChefLicensing
         invoke_get_api(self.class::END_POINTS[:LIST_LICENSES])
       end
 
+      def clear_cache(endpoint, params = {})
+        cache_key = construct_cache_key(endpoint, params)
+        @cache_manager.delete(cache_key)
+      end
+
       private
 
       attr_reader :logger

--- a/components/ruby/lib/chef-licensing/restful_client/base.rb
+++ b/components/ruby/lib/chef-licensing/restful_client/base.rb
@@ -78,6 +78,7 @@ module ChefLicensing
       end
 
       def clear_cache(endpoint, params = {})
+        logger.debug("Clearing cache for #{endpoint} with params #{params}")
         cache_key = construct_cache_key(endpoint, params)
         @cache_manager.delete(cache_key)
       end

--- a/components/ruby/spec/restful_client_v1_spec.rb
+++ b/components/ruby/spec/restful_client_v1_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe ChefLicensing::RestfulClient::V1 do
     end
   end
 
-  context "when cache is enabled and the endpoint invoked is included in CACHE_ENDPOINTS" do
+  context "when cache is enabled and the endpoint invoked is included in CACHE_ENDPOINTS & clearing cache" do
     Dir.mktmpdir do |dir|
       let(:license_keys) { "tmns-bea68bbb-1e85-44ea-8b98-a654b011174b-0000" }
       let(:client_data) { JSON.parse(File.read("spec/fixtures/api_response_data/valid_client_api_response.json")) }
@@ -217,6 +217,12 @@ RSpec.describe ChefLicensing::RestfulClient::V1 do
         expect(output.string).not_to include("Fetching data from server")
         expect(output.string).not_to include("Storing data in cache")
         expect(output.string).not_to include("Cache not found")
+      end
+
+      it "clears the cache" do
+        expect(base_obj.clear_cache(ChefLicensing::RestfulClient::V1::END_POINTS[:CLIENT], { licenseId: license_keys, entitlementId: ChefLicensing::Config.chef_entitlement_id })).to be_truthy
+        expect(output.string).to include("Clearing cache for #{ChefLicensing::RestfulClient::V1::END_POINTS[:CLIENT]}")
+        expect(output.string).to include("CacheManager: Deleting")
       end
     end
   end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR introduces an endpoint in the base class of restful client which can be used by the specific api classes like client to clear cache of their respective endpoints.

Note: The classes invoking the `clear_cache` needs to send two parameters: `endpoint` and the params which they send to call their respective endpoints in the base class. This is required to form the cache key for deletion.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
