### PR TITLE
CHEF-4150 Hard enforcement enabled - when license expired

### DIFF
--- a/components/ruby/lib/chef-licensing/license_key_fetcher.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher.rb
@@ -86,15 +86,9 @@ module ChefLicensing
       end
 
       # Scenario: When a user is prompted for license expiry and license is not yet renewed
-      if %i{prompt_license_about_to_expire prompt_license_expired_local_mode prompt_license_exhausted}.include?(config[:start_interaction])
-        # Not blocking any license type in case of expiry or for commercial license exhaustion
-        if config[:start_interaction] == :prompt_license_exhausted
-          # If user has exhausted commercial license, we are not blocking
-          # we are blocking only when user has exhausted free license, hence LicenseKeyNotFetchedError is raised for free license
-          return @license_keys if license.license_type.downcase == "commercial"
-        else
-          return @license_keys
-        end
+      if %i{prompt_license_about_to_expire prompt_license_expired_local_mode}.include?(config[:start_interaction])
+        # Not blocking any license type in case of expiry
+        return @license_keys
       end
 
       # Otherwise nothing was able to fetch a license. Throw an exception.

--- a/components/ruby/lib/chef-licensing/license_key_fetcher.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher.rb
@@ -88,8 +88,8 @@ module ChefLicensing
       # Scenario: When a user is prompted with license about to expire message and license is not yet renewed
       # Scenario: When a user is prompted with license expired message in grace period and license is not yet renewed
       if license && !license.expired?
-        # Not blocking any license type in case of license about to expire and grace scenario only
-        return @license_keys
+        # Return license keys unless it is a free license that has been exhausted
+        return @license_keys unless license.exhausted? && license.license_type.downcase == "free"
       end
 
       # Otherwise nothing was able to fetch a license. Throw an exception.

--- a/components/ruby/lib/chef-licensing/license_key_fetcher.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher.rb
@@ -73,7 +73,7 @@ module ChefLicensing
         # Licenses expiration check
         # Client API possible errors will be handled in software entitlement check call (made after this)
         # client_api_call_error is set to true when there is an error in licenses_active? call
-        if licenses_active? || client_api_call_error || client_api_call_error
+        if licenses_active? || client_api_call_error
           return @license_keys
         else
           # Prompts if the keys are expired or expiring
@@ -140,7 +140,8 @@ module ChefLicensing
         # Scenario: When a user is prompted with license about to expire message and license is not yet renewed
         # Scenario: When a user is prompted with license expired message in grace period and license is not yet renewed
         # Not blocking any license type in case of license about to expire and grace scenario only
-        return @license_keys
+        # Return license keys unless it is a free license that has been exhausted
+        return @license_keys unless license.exhausted? && license.license_type.downcase == "free"
       end
 
       # Otherwise nothing was able to fetch a license. Throw an exception.

--- a/components/ruby/spec/chef_licensing_ux_spec.rb
+++ b/components/ruby/spec/chef_licensing_ux_spec.rb
@@ -675,8 +675,9 @@ RSpec.describe ChefLicensing::TUIEngine do
 
       before do
         ChefLicensing::Context.current_context = nil
-        license_key_fetcher.fetch_and_persist
       end
+
+      it { expect { license_key_fetcher.fetch_and_persist }.to raise_error(ChefLicensing::LicenseKeyFetcher::LicenseKeyNotFetchedError) }
 
       it "checks if the license is persisted" do
         expect(license_key_fetcher.fetch).to eq([expired_trial_license_key])

--- a/components/ruby/spec/license_key_fetcher_spec.rb
+++ b/components/ruby/spec/license_key_fetcher_spec.rb
@@ -835,7 +835,7 @@ RSpec.describe ChefLicensing::LicenseKeyFetcher do
       end
     end
 
-    context "when the license key is expired and no day left, lesser than a min threshold of 1 day" do
+    context "when the license key is expired, it raises error and blocks execution" do
 
       let(:client_data_expired) {
         {
@@ -887,12 +887,7 @@ RSpec.describe ChefLicensing::LicenseKeyFetcher do
                        headers: { content_type: "application/json" })
         end
 
-        it "does not nags that it is about to expire but that it is expired" do
-          license_key_fetcher.fetch_and_persist
-          expect(license_key_fetcher.config[:start_interaction]).to_not eq(:prompt_license_about_to_expire)
-          expect(license_key_fetcher.config[:start_interaction]).to_not eq(nil)
-          expect(license_key_fetcher.config[:start_interaction]).to eq(:prompt_license_expired)
-        end
+        it { expect { license_key_fetcher.fetch_and_persist }.to raise_error(ChefLicensing::LicenseKeyFetcher::LicenseKeyNotFetchedError) }
       end
     end
   end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Hard enforcement enabled - when a license is expired. Raises error.
- No hard enforcement when a license is in grace status
- No hard enforcement when a license is about to expire.

**DO NOT MERGE:
This change is for post-release and will only be merged at a much later date based on business requirement.**
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
