### PR TITLE
CHEF-5997 & CHEF-5919: Replace license generation UI with link to web form

### DIFF
--- a/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
@@ -301,9 +301,10 @@ interactions:
       "3. Commercial License\n": commercial_license_selection
       "4. Quit license generation": exit
 
-  # TODO: Update link with the actual license generation link
+  # Note: The below link is specific to InSpec; as per PO there will be different link for other products.
+  #       We need to update the link for other products once we have the link or update to a common link.
   free_trial_license_selection:
-    messages: ["<%= input[:pastel].yellow(\"!\") %> Kindly complete the user registration at <%= input[:pastel].blue.underline.blue(\"https://www.chef.io\") %>\nOnce you submit the details, you will receive the license ID on the email id you provided.\n\nSelect an option",
+    messages: ["<%= input[:pastel].yellow(\"!\") %> Kindly complete the user registration at <%= input[:pastel].blue.underline.blue(\"https://www.chef.io/licensing/inspec/license-genertation-free-trial\") %>\nOnce you submit the details, you will receive the license ID on the email id you provided.\n\nSelect an option",
       [
       Validate license now,
       Quit and validate license later

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
@@ -316,10 +316,11 @@ interactions:
       "Validate license now": ask_for_license_id
       "Quit and validate license later": validate_license_later_message
 
+  # TODO: Update the link for other ways to validate the license document.
   validate_license_later_message:
     messages: |
       You can validate the license later on by selecting <%= input[:pastel].bold("'I already have a license ID'") %> when prompted for license.
-      License can also be validated by running <%= input[:pastel].bold("#{ChefLicensing::Config.chef_executable_name} license add") %> command and then selecting <%= input[:pastel].bold("'Validate a generated license ID option'") %>.
+      To learn about more ways to validate the license, kindly visit <%= input[:pastel].blue.underline.blue("www.docs.chef.io") %>.
     paths: [exit]
 
   commercial_license_selection:

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
@@ -304,10 +304,16 @@ interactions:
   # TODO: Fix the message and update link with the actual license generation link
   free_trial_license_selection:
     messages: ["Complete the form available at <%= input[:pastel].blue.underline.blue(\"https://www.chef.io\") %>\n",
-      [Quit]
+      [
+      Validate a generated license ID,
+      Quit
+      ]
     ]
     prompt_type: "select"
-    paths: [exit_with_message]
+    paths: [exit_with_message, ask_for_license_id]
+    response_path_map:
+      "Validate a generated license ID": ask_for_license_id
+      "Quit": exit_with_message
 
   commercial_license_selection:
     messages: ["Get in touch with the Sales Team by filling out the form available at <%= input[:pastel].blue.underline.blue(\"https://www.chef.io/contact-us\") %>\n",

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
@@ -301,19 +301,25 @@ interactions:
       "3. Commercial License\n": commercial_license_selection
       "4. Quit license generation": exit
 
-  # TODO: Fix the message and update link with the actual license generation link
+  # TODO: Update link with the actual license generation link
   free_trial_license_selection:
-    messages: ["Complete the form available at <%= input[:pastel].blue.underline.blue(\"https://www.chef.io\") %>\n",
+    messages: ["<%= input[:pastel].yellow(\"!\") %> Kindly complete the user registration at <%= input[:pastel].blue.underline.blue(\"https://www.chef.io\") %>\nOnce you submit the details, you will receive the license ID on the email id you provided.\n\nSelect an option",
       [
-      Validate a generated license ID,
-      Quit
+      Validate license now,
+      Quit and validate license later
       ]
     ]
     prompt_type: "select"
-    paths: [exit_with_message, ask_for_license_id]
+    paths: [validate_license_later_message, ask_for_license_id]
     response_path_map:
-      "Validate a generated license ID": ask_for_license_id
-      "Quit": exit_with_message
+      "Validate license now": ask_for_license_id
+      "Quit and validate license later": validate_license_later_message
+
+  validate_license_later_message:
+    messages: |
+      You can validate the license later on by selecting <%= input[:pastel].bold("'I already have a license ID'") %> when prompted for license.
+      License can also be validated by running <%= input[:pastel].bold("#{ChefLicensing::Config.chef_executable_name} license add") %> command and then selecting <%= input[:pastel].bold("'Validate a generated license ID option'") %>.
+    paths: [exit]
 
   commercial_license_selection:
     messages: ["Get in touch with the Sales Team by filling out the form available at <%= input[:pastel].blue.underline.blue(\"https://www.chef.io/contact-us\") %>\n",

--- a/components/ruby/spec/chef_licensing_ux_spec.rb
+++ b/components/ruby/spec/chef_licensing_ux_spec.rb
@@ -238,12 +238,13 @@ RSpec.describe ChefLicensing::TUIEngine do
     end
   end
 
-  context "free license generation ux, user follows all steps correctly" do
+  context "free license generation ux, user follows all steps correctly and exits" do
     let(:start_interaction) { :start }
 
     before do
       prompt.input << simulate_down_arrow
       prompt.input << "\n\n"
+      prompt.input << simulate_down_arrow
       prompt.input << "\n"
       prompt.input.rewind
     end
@@ -259,6 +260,48 @@ RSpec.describe ChefLicensing::TUIEngine do
         ask_for_all_license_type
         free_trial_license_selection
         exit_with_message
+      }
+    }
+
+    it "generates the license successfully traversing through the interactions in expected order" do
+      expect { tui_engine.append_info_to_input(additional_info_for_tui_engine) }.to_not raise_error
+      expect { tui_engine.run_interaction(start_interaction) }.to_not raise_error
+      expect(tui_engine.traversed_interaction).to eq(expected_flow_for_license_generation)
+      expect(prompt.output.string).to include("I don't have a license ID and would like to generate a new license ID")
+      expect(prompt.output.string).to include("Select the type of license below and then enter user details")
+      # TODO: expect the new form sentence to include later
+    end
+  end
+
+  context "free license generation ux, user follows all steps correctly and provides free license key; post generation from web" do
+    let(:start_interaction) { :start }
+
+    before do
+      prompt.input << simulate_down_arrow
+      prompt.input << "\n\n\n"
+      prompt.input << valid_free_license_key
+      prompt.input << "\n"
+      prompt.input.rewind
+    end
+
+    let(:tui_engine) { described_class.new(opts) }
+
+    let(:expected_flow_for_license_generation) {
+      %i{
+        start
+        ask_if_user_has_license_id
+        info_of_license_types
+        filter_license_type_options
+        ask_for_all_license_type
+        free_trial_license_selection
+        ask_for_license_id
+        validate_license_id_pattern
+        validate_license_id_with_api
+        validate_license_restriction
+        validate_license_expiration
+        validation_success
+        display_license_info
+        fetch_license_id
       }
     }
 
@@ -407,14 +450,16 @@ RSpec.describe ChefLicensing::TUIEngine do
     end
   end
 
-  context "trial license generation ux, user follows all steps correctly" do
+  context "trial license generation ux, user follows all steps correctly and exits" do
     let(:start_interaction) { :start }
 
     before do
       prompt.input << simulate_down_arrow
       prompt.input << "\n"
       prompt.input << simulate_down_arrow
-      prompt.input << "\n\n"
+      prompt.input << "\n"
+      prompt.input << simulate_down_arrow
+      prompt.input << "\n"
       prompt.input.rewind
     end
 
@@ -429,6 +474,52 @@ RSpec.describe ChefLicensing::TUIEngine do
         ask_for_all_license_type
         free_trial_license_selection
         exit_with_message
+      }
+    }
+
+    it "generates the license successfully traversing through the interactions in expected order" do
+      expect { tui_engine.append_info_to_input(additional_info_for_tui_engine) }.to_not raise_error
+      expect { tui_engine.run_interaction(start_interaction) }.to_not raise_error
+      expect(tui_engine.traversed_interaction).to eq(expected_flow_for_license_generation)
+      expect(prompt.output.string).to include("I don't have a license ID and would like to generate a new license ID")
+      expect(prompt.output.string).to include("Select the type of license below and then enter user details")
+      expect(prompt.output.string).to include("2. Trial License")
+      expect(prompt.output.string).to include("No. of units: Unlimited targets")
+      # TODO: expect the new form sentence to include later
+    end
+  end
+
+  context "trial license generation ux, user follows all steps correctly and provides a trial license; post generation from web" do
+    let(:start_interaction) { :start }
+
+    before do
+      prompt.input << simulate_down_arrow
+      prompt.input << "\n"
+      prompt.input << simulate_down_arrow
+      prompt.input << "\n\n"
+      prompt.input << valid_trial_license_key
+      prompt.input << "\n"
+      prompt.input.rewind
+    end
+
+    let(:tui_engine) { described_class.new(opts) }
+
+    let(:expected_flow_for_license_generation) {
+      %i{
+        start
+        ask_if_user_has_license_id
+        info_of_license_types
+        filter_license_type_options
+        ask_for_all_license_type
+        free_trial_license_selection
+        ask_for_license_id
+        validate_license_id_pattern
+        validate_license_id_with_api
+        validate_license_restriction
+        validate_license_expiration
+        validation_success
+        display_license_info
+        fetch_license_id
       }
     }
 

--- a/components/ruby/spec/chef_licensing_ux_spec.rb
+++ b/components/ruby/spec/chef_licensing_ux_spec.rb
@@ -271,7 +271,7 @@ RSpec.describe ChefLicensing::TUIEngine do
       expect(prompt.output.string).to include("Select the type of license below and then enter user details")
       expect(prompt.output.string).to include("Quit and validate license later")
       expect(prompt.output.string).to include("You can validate the license later on by selecting")
-      expect(prompt.output.string).to include("License can also be validated by running")
+      expect(prompt.output.string).to include("To learn about more ways to validate the license, kindly visit")
     end
   end
 
@@ -491,7 +491,7 @@ RSpec.describe ChefLicensing::TUIEngine do
       expect(prompt.output.string).to include("No. of units: Unlimited targets")
       expect(prompt.output.string).to include("Quit and validate license later")
       expect(prompt.output.string).to include("You can validate the license later on by selecting")
-      expect(prompt.output.string).to include("License can also be validated by running")
+      expect(prompt.output.string).to include("To learn about more ways to validate the license, kindly visit")
     end
   end
 

--- a/components/ruby/spec/chef_licensing_ux_spec.rb
+++ b/components/ruby/spec/chef_licensing_ux_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe ChefLicensing::TUIEngine do
         filter_license_type_options
         ask_for_all_license_type
         free_trial_license_selection
-        exit_with_message
+        validate_license_later_message
       }
     }
 
@@ -269,7 +269,9 @@ RSpec.describe ChefLicensing::TUIEngine do
       expect(tui_engine.traversed_interaction).to eq(expected_flow_for_license_generation)
       expect(prompt.output.string).to include("I don't have a license ID and would like to generate a new license ID")
       expect(prompt.output.string).to include("Select the type of license below and then enter user details")
-      # TODO: expect the new form sentence to include later
+      expect(prompt.output.string).to include("Quit and validate license later")
+      expect(prompt.output.string).to include("You can validate the license later on by selecting")
+      expect(prompt.output.string).to include("License can also be validated by running")
     end
   end
 
@@ -311,7 +313,9 @@ RSpec.describe ChefLicensing::TUIEngine do
       expect(tui_engine.traversed_interaction).to eq(expected_flow_for_license_generation)
       expect(prompt.output.string).to include("I don't have a license ID and would like to generate a new license ID")
       expect(prompt.output.string).to include("Select the type of license below and then enter user details")
-      # TODO: expect the new form sentence to include later
+      expect(prompt.output.string).to include("Kindly complete the user registration at")
+      expect(prompt.output.string).to include("Once you submit the details, you will receive the license ID on the email id you provided.")
+      expect(prompt.output.string).to include("Validate license now")
     end
   end
 
@@ -473,7 +477,7 @@ RSpec.describe ChefLicensing::TUIEngine do
         filter_license_type_options
         ask_for_all_license_type
         free_trial_license_selection
-        exit_with_message
+        validate_license_later_message
       }
     }
 
@@ -485,7 +489,9 @@ RSpec.describe ChefLicensing::TUIEngine do
       expect(prompt.output.string).to include("Select the type of license below and then enter user details")
       expect(prompt.output.string).to include("2. Trial License")
       expect(prompt.output.string).to include("No. of units: Unlimited targets")
-      # TODO: expect the new form sentence to include later
+      expect(prompt.output.string).to include("Quit and validate license later")
+      expect(prompt.output.string).to include("You can validate the license later on by selecting")
+      expect(prompt.output.string).to include("License can also be validated by running")
     end
   end
 
@@ -531,7 +537,9 @@ RSpec.describe ChefLicensing::TUIEngine do
       expect(prompt.output.string).to include("Select the type of license below and then enter user details")
       expect(prompt.output.string).to include("2. Trial License")
       expect(prompt.output.string).to include("No. of units: Unlimited targets")
-      # TODO: expect the new form sentence to include later
+      expect(prompt.output.string).to include("Kindly complete the user registration at")
+      expect(prompt.output.string).to include("Once you submit the details, you will receive the license ID on the email id you provided.")
+      expect(prompt.output.string).to include("Validate license now")
     end
   end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR enhances the user experience to be able to provide a license id when the user follows either the free or trial license generation journey in the cli.

Additionally, it updates the web link for free/trial license generation. 

## New Behavior
```
...
We have the following types of licenses.
Select the type of license below and then enter user details
 1. Free License
     Validity: Unlimited
     No. of units: 10 targets

! Kindly complete the user registration at https://www.chef.io/licensing/inspec/license-genertation-free-trial
Once you submit the details, you will receive the license ID on the email id you provided.

Select an option (Press ↑/↓ arrow to move and Enter to select)
‣ Validate license now
  Quit and validate license later
```

## Current Behavior
This is to eliminate the hassle for the user to quit the process and add the license with the initial prompts again (either self invocation prompts by chef-licensing or via license add)
```
...
We have the following types of licenses.
Select the type of license below and then enter user details
 1. Free License
     Validity: Unlimited
     No. of units: 10 targets

Complete the form available at https://www.chef.io
 Quit
Thank you.
[2023-08-30T17:30:39+05:30] ERROR: Chef InSpec cannot execute without valid licenses.
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
- **CHEF-5997: Add ability for the user to provide license id during the license generation step** (subtask of CHEF-5919: License Generation Flow - Add a webform link when user tries to generate free and trial license)
- **CHEF-5919: License Generation Flow - Add a webform link when user tries to generate free and trial license**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
