### PR TITLE
Local licensing mode - Error handling for license expiration check

### DIFF
--- a/components/ruby/lib/chef-licensing/license_key_fetcher.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher.rb
@@ -72,6 +72,7 @@ module ChefLicensing
       unless @license_keys.empty?
         # Licenses expiration check
         # Client API possible errors will be handled in software entitlement check call (made after this)
+        # client_api_call_error is set to true when there is an error in licenses_active? call
         if licenses_active? || client_api_call_error
           return @license_keys
         else
@@ -117,6 +118,7 @@ module ChefLicensing
       # Return keys if license keys are active and not expired or expiring
       # Return keys if there is any error in /client API call, and do not block the flow.
       # Client API possible errors will be handled in software entitlement check call (made after this)
+      # client_api_call_error is set to true when there is an error in licenses_active? call
       return @license_keys if (!@license_keys.empty? && licenses_active?) || client_api_call_error
 
       # Lowest priority is to interactively prompt if we have a TTY

--- a/components/ruby/lib/chef-licensing/license_key_fetcher.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher.rb
@@ -71,7 +71,8 @@ module ChefLicensing
 
       unless @license_keys.empty?
         # Licenses expiration check
-        if licenses_active?
+        # Client API possible errors will be handled in software entitlement check call (made after this)
+        if licenses_active? || client_api_call_error
           return @license_keys
         else
           # Prompts if the keys are expired or expiring


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This is follow-up missing change on PR #127
In Local licensing mode also, we needed error handling for the license expiration check
This check was missed.

This check makes sure that any `/client` error encountered is not raised from this point, but let the software entitlement check that will happen again after this call to handle all these errors.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
