### PR TITLE
Fixes deprecation warning for active_support cache format_version 6.1

### DIFF
--- a/components/ruby/lib/chef-licensing/restful_client/base.rb
+++ b/components/ruby/lib/chef-licensing/restful_client/base.rb
@@ -131,6 +131,10 @@ module ChefLicensing
       end
 
       def get_connection(url = nil)
+        # Support for config.active_support.cache_format_version 6.1 is deprecated
+        # below line configures the cache format version to 7.0 to get rid of the deprication warning messages
+        # TODO: remove explicit assignment to version 7.0 once the deprecation is removed from ActiveSupport.
+        ::ActiveSupport::Cache.format_version = 7.0
         store = ::ActiveSupport::Cache.lookup_store(:file_store, Dir.tmpdir)
         Faraday.new(url: url) do |config|
           config.request :json


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Configures the active support cache format version to 7.0 as default 6.1 is deprecated and will be removed and floods the console with deprecation warning messages.
https://buildkite.com/chef/inspec-inspec-main-verify-private/builds/237#018b12c2-c5a6-4469-9df6-8f0a51e5c3f9/1328-1364
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
