### PR TITLE
Add constraint to ActiveSupport gem to use version lower than 7.1

### DIFF
--- a/components/ruby/Gemfile.lock
+++ b/components/ruby/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     chef-licensing (0.7.4)
-      activesupport (~> 7.0, >= 7.0.4.2)
+      activesupport (~> 7.0, < 7.1)
       chef-config (>= 15)
       faraday (>= 1, < 3)
       faraday-http-cache
@@ -115,6 +115,7 @@ GEM
     wisper (2.0.1)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-19
   x86_64-darwin-21
   x86_64-linux
@@ -129,4 +130,4 @@ DEPENDENCIES
   webmock (~> 3.18, >= 3.18.1)
 
 BUNDLED WITH
-   2.3.18
+   2.3.26

--- a/components/ruby/chef-licensing.gemspec
+++ b/components/ruby/chef-licensing.gemspec
@@ -30,6 +30,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "tty-prompt", "~> 0.23"
   spec.add_dependency "faraday", ">= 1", "< 3"
   spec.add_dependency "faraday-http-cache"
-  spec.add_dependency "activesupport", "~> 7.0", ">= 7.0.4.2"
+  # Note: 7.1.0 does not defaults its cache_format_version to 7.1 but 6.1 instead which gives deprecation warnings
+  # Remove the version constraint when we can upgrade to 7.1.1 post stable release of Activesupport 7.1
+  # Similar issue with 7.0 existed: https://github.com/rails/rails/pull/45293
+  spec.add_dependency "activesupport", "~> 7.0", "< 7.1"
   spec.add_dependency "tty-spinner", "~> 0.9.3"
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The latest version of `ActiveSupport` i.e. `[7.1.0](https://rubygems.org/gems/activesupport/versions/7.1.0) - October 05, 2023 (250 KB)` has some issue with setting the default config to use its cache_format_version as 7.1.0 and picks 6.1 instead by default.

This leads to a deprecation warning when using ActiveSupport Cache in our Faraday connection. Hence, until the ActiveSupport gem has a stable release and the issue is fixed, we continue to use the 7.0.x versions of ActiveSupport in our library.

```
DEPRECATION WARNING: Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.

Check the Rails upgrade guide at https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
for more information on how to upgrade.
 (called from get_connection at ../chef-licensing/components/ruby/lib/chef-licensing/restful_client/base.rb:134)
DEPRECATION WARNING: Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.
```

Similar issue existed with 7.0.x - https://github.com/rails/rails/pull/45293 which has been fixed.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
