### PR TITLE
CHEF-7258 License context caching and fetching

### DIFF
--- a/components/ruby/lib/chef-licensing.rb
+++ b/components/ruby/lib/chef-licensing.rb
@@ -8,6 +8,7 @@ require "chef-licensing/exceptions/software_not_entitled"
 require "chef-licensing/exceptions/client_error"
 require "chef-licensing/api/client"
 require "chef-licensing/license_key_fetcher/prompt"
+require "chef-licensing/context"
 
 module ChefLicensing
   class << self
@@ -65,6 +66,10 @@ module ChefLicensing
 
     def add_license
       ChefLicensing::LicenseKeyFetcher.add_license
+    end
+
+    def license_context
+      ChefLicensing::Context.license
     end
   end
 end

--- a/components/ruby/lib/chef-licensing/context.rb
+++ b/components/ruby/lib/chef-licensing/context.rb
@@ -25,9 +25,20 @@ module ChefLicensing
         current_context(options).license_keys
       end
 
+      # Return license context object via current context
+      def license(options = {})
+        current_context(options).license
+      end
+
+      # Set license context object via current context
+      # Example: ChefLicensing::Context.license = license_context_object
+      def license=(license)
+        current_context.license = license
+      end
+
       private
 
-      def current_context(options)
+      def current_context(options = {})
         return @current_context if @current_context
 
         @current_context = context_based_on_state(options)
@@ -63,12 +74,36 @@ module ChefLicensing
       @state.license_keys
     end
 
+    # Get license context from local or global state
+    def license
+      @state.license
+    end
+
+    # Set license context from local or global state
+    def license=(license)
+      @state.license = license
+    end
+
     class State
       attr_accessor :context, :options
 
       # @abstract
       def license_keys
         raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+      end
+
+      # Get license context in local or global state
+      def license
+        if @license_keys.empty?
+          @license ||= nil
+        else
+          @license ||= ChefLicensing.client(license_keys: @license_keys)
+        end
+      end
+
+      # Set license context in local or global state
+      def license=(license)
+        @license ||= license
       end
     end
 

--- a/components/ruby/lib/chef-licensing/context.rb
+++ b/components/ruby/lib/chef-licensing/context.rb
@@ -94,10 +94,10 @@ module ChefLicensing
 
       # Get license context in local or global state
       def license
-        if @license_keys.empty?
+        if license_keys.empty?
           @license ||= nil
         else
-          @license ||= ChefLicensing.client(license_keys: @license_keys)
+          @license ||= ChefLicensing.client(license_keys: license_keys)
         end
       end
 

--- a/components/ruby/lib/chef-licensing/license_key_fetcher.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher.rb
@@ -215,6 +215,10 @@ module ChefLicensing
       # This call returns a license based on client logic
       # This API call is only made when multiple license keys are present or if client call was never done
       self.license = ChefLicensing.client(license_keys: @license_keys) if !license || @license_keys.count > 1
+
+      # Cache license context
+      ChefLicensing::Context.license = license
+
       # Intentional lag of 2 seconds when license is expiring or expired
       sleep 2 if license.expiring_or_expired?
       spinner.success # Stop the spinner

--- a/components/ruby/spec/chef-licensing/context_spec.rb
+++ b/components/ruby/spec/chef-licensing/context_spec.rb
@@ -1,0 +1,42 @@
+require "chef-licensing/context"
+require "chef-licensing"
+
+RSpec.describe ChefLicensing::Context do
+  let(:output) { StringIO.new }
+  let(:logger) { Logger.new(output) }
+  let(:client_api_data) { JSON.parse(File.read("spec/fixtures/api_response_data/valid_client_api_response.json")) }
+  let(:argv) { [] }
+  let(:env) { {} }
+  let(:opts) {
+    {
+      dir: Dir.mktmpdir,
+      output: output,
+      logger: logger,
+      argv: argv,
+      env: env,
+    }
+  }
+
+  before do
+    ChefLicensing.configure do |config|
+      config.chef_product_name = "inspec"
+      config.chef_entitlement_id = "3ff52c37-e41f-4f6c-ad4d-365192205968"
+      config.license_server_url = "http://localhost-license-server/License"
+      config.is_local_license_service = nil
+    end
+    ChefLicensing::Context.current_context = nil
+    stub_request(:get, "#{ChefLicensing::Config.license_server_url}/v1/listLicenses")
+      .to_return(body: { data: ["tmns-0f76efaf-b45b-4d92-86b2-2d144ce73dfa-150"], status_code: 200 }.to_json,
+    headers: { content_type: "application/json" })
+    stub_request(:get, "#{ChefLicensing::Config.license_server_url}/v1/client")
+      .with(query: { licenseId: "tmns-0f76efaf-b45b-4d92-86b2-2d144ce73dfa-150", entitlementId: ChefLicensing::Config.chef_entitlement_id })
+      .to_return(body: { data: client_api_data, status_code: 200 }.to_json,
+              headers: { content_type: "application/json" })
+  end
+
+  describe "Fetching license context" do
+    it "returns license context succesfully" do
+      expect(ChefLicensing::Context.license.class).to eq(ChefLicensing::License)
+    end
+  end
+end

--- a/components/ruby/spec/chef_licensing_ux_spec.rb
+++ b/components/ruby/spec/chef_licensing_ux_spec.rb
@@ -343,6 +343,10 @@ RSpec.describe ChefLicensing::TUIEngine do
       let(:tui_engine) { described_class.new(opts) }
 
       before do
+        ChefLicensing.configure do |config|
+          config.is_local_license_service = nil
+        end
+        ChefLicensing::Context.current_context = nil
         license_key_fetcher.fetch_and_persist
       end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
License context caching and fetching to enable:
1. Caching license context via fetch and persist when license context is available
2. Ability to fetch license context if available or to fetch the fresh context via API call using license keys.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
