### PR TITLE
CHEF-8798: Validate server's response content-type to ensure functionality or display appropriate error messages

### DIFF
--- a/components/ruby/lib/chef-licensing/exceptions/unsupported_content_type.rb
+++ b/components/ruby/lib/chef-licensing/exceptions/unsupported_content_type.rb
@@ -1,0 +1,9 @@
+require_relative "error"
+
+module ChefLicensing
+  class UnsupportedContentType < Error
+    def message
+      super || "Unsupported content type"
+    end
+  end
+end

--- a/components/ruby/lib/chef-licensing/restful_client/base.rb
+++ b/components/ruby/lib/chef-licensing/restful_client/base.rb
@@ -7,6 +7,7 @@ require_relative "../exceptions/restful_client_connection_error"
 require_relative "../exceptions/missing_api_credentials_error"
 require_relative "../config"
 require_relative "middleware/exceptions_handler"
+require_relative "middleware/content_type_validator"
 
 module ChefLicensing
   module RestfulClient
@@ -137,6 +138,7 @@ module ChefLicensing
           config.response :json, parser_options: { object_class: OpenStruct }
           config.use Faraday::HttpCache, shared_cache: false, logger: logger, store: store
           config.use Middleware::ExceptionsHandler
+          config.use Middleware::ContentTypeValidator
           config.adapter Faraday.default_adapter
         end
       end

--- a/components/ruby/lib/chef-licensing/restful_client/middleware/content_type_validator.rb
+++ b/components/ruby/lib/chef-licensing/restful_client/middleware/content_type_validator.rb
@@ -1,0 +1,24 @@
+require "faraday/middleware"
+require_relative "../../../chef-licensing/exceptions/unsupported_content_type"
+
+module Middleware
+  class ContentTypeValidator < Faraday::Middleware
+    def call(env)
+      @app.call(env).on_complete do |response_env|
+        content_type = response_env[:response_headers]["content-type"]
+        body = response_env[:body]
+        # trim the body to 1000 characters to avoid printing a huge string in the error message
+        body = body[0..1000] if body.is_a?(String)
+        raise ChefLicensing::UnsupportedContentType, error_message(content_type, body) unless content_type == "application/json"
+      end
+    end
+
+    def error_message(content_type, body = nil)
+      <<~EOM
+        Expected 'application/json' content-type, but received '#{content_type}' from the licensing server.
+        Snippet of body: `#{body}`
+        Possible causes: Check for firewall restrictions, ensure proper server response, or seek support assistance.
+      EOM
+    end
+  end
+end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR implements content-type validation for server responses. The Chef Licensing library requires an 'application/json' content type response for all its APIs.

With this handling when the server return's a non json type content it gives the error as shown below:
```
❯ bundle exec inspec exec
[2023-12-01T18:09:43+05:30] ERROR: Expected 'application/json' content-type, but received 'text/plain; charset=utf-8' from the licensing server.
Snippet of body: `This is a test page for the dummy server!`
Possible causes: Check for firewall restrictions, ensure proper server response, or seek support assistance.
```

### Screenshot
<img width="1332" alt="image" src="https://github.com/chef/chef-licensing/assets/98935583/4b8796ec-69bb-478c-8f72-dbf1d30516d7">


## Related Issue
CHEF-8798: Validate server's response content-type to ensure functionality or display appropriate error messages
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
