### PR TITLE
CHEF-4925: Show a license enforcement message on exceeding target limit for commercial license

### DIFF
--- a/components/ruby/lib/chef-licensing/license.rb
+++ b/components/ruby/lib/chef-licensing/license.rb
@@ -133,7 +133,7 @@ module ChefLicensing
       status.eql?("Expired")
     end
 
-    def limit_exhausted?
+    def exhausted?
       status.eql?("Exhausted")
     end
 

--- a/components/ruby/lib/chef-licensing/license.rb
+++ b/components/ruby/lib/chef-licensing/license.rb
@@ -133,6 +133,10 @@ module ChefLicensing
       status.eql?("Expired")
     end
 
+    def limit_exhausted?
+      status.eql?("Exhausted")
+    end
+
     def active?
       status.eql?("Active")
     end

--- a/components/ruby/lib/chef-licensing/license_key_fetcher.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher.rb
@@ -86,7 +86,7 @@ module ChefLicensing
       end
 
       # Scenario: When a user is prompted for license expiry and license is not yet renewed
-      if %i{prompt_license_about_to_expire prompt_license_expired_local_mode}.include?(config[:start_interaction])
+      if %i{prompt_license_about_to_expire prompt_license_expired_local_mode prompt_license_exhausted}.include?(config[:start_interaction])
         # Not blocking any license type in case of expiry
         return @license_keys
       end
@@ -136,7 +136,7 @@ module ChefLicensing
       end
 
       # Scenario: When a user is prompted for license expiry and license is not yet renewed
-      if new_keys.empty? && %i{prompt_license_about_to_expire prompt_license_expired}.include?(config[:start_interaction])
+      if new_keys.empty? && %i{prompt_license_about_to_expire prompt_license_expired prompt_license_exhausted}.include?(config[:start_interaction])
         # Not blocking any license type in case of expiry
         return @license_keys
       end

--- a/components/ruby/lib/chef-licensing/license_key_fetcher.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher.rb
@@ -230,7 +230,7 @@ module ChefLicensing
         config[:start_interaction] = :prompt_license_about_to_expire
         prompt_fetcher.config = config
         false
-      elsif license.exhausted? && license.license_type == "commercial"
+      elsif license.exhausted? && license.license_type.downcase == "commercial"
         config[:start_interaction] = :prompt_commercial_license_exhausted
         prompt_fetcher.config = config
         false

--- a/components/ruby/lib/chef-licensing/license_key_fetcher.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher.rb
@@ -230,6 +230,10 @@ module ChefLicensing
         config[:start_interaction] = :prompt_license_about_to_expire
         prompt_fetcher.config = config
         false
+      elsif license.limit_exhausted?
+        config[:start_interaction] = :prompt_license_exhausted
+        prompt_fetcher.config = config
+        false
       else
         true
       end

--- a/components/ruby/lib/chef-licensing/license_key_fetcher.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher.rb
@@ -86,7 +86,7 @@ module ChefLicensing
       end
 
       # Scenario: When a user is prompted for license expiry and license is not yet renewed
-      if %i{prompt_license_about_to_expire prompt_license_expired_local_mode prompt_commercial_license_exhausted}.include?(config[:start_interaction])
+      if %i{prompt_license_about_to_expire prompt_license_expired_local_mode prompt_license_exhausted}.include?(config[:start_interaction])
         # Not blocking any license type in case of expiry or for commercial license exhaustion
         return @license_keys
       end
@@ -136,7 +136,7 @@ module ChefLicensing
       end
 
       # Scenario: When a user is prompted for license expiry and license is not yet renewed
-      if new_keys.empty? && %i{prompt_license_about_to_expire prompt_license_expired prompt_commercial_license_exhausted}.include?(config[:start_interaction])
+      if new_keys.empty? && %i{prompt_license_about_to_expire prompt_license_expired prompt_license_exhausted}.include?(config[:start_interaction])
         # Not blocking any license type in case of expiry or for commercial license exhaustion
         return @license_keys
       end
@@ -231,7 +231,7 @@ module ChefLicensing
         prompt_fetcher.config = config
         false
       elsif license.exhausted? && license.license_type.downcase == "commercial"
-        config[:start_interaction] = :prompt_commercial_license_exhausted
+        config[:start_interaction] = :prompt_license_exhausted
         prompt_fetcher.config = config
         false
       else

--- a/components/ruby/lib/chef-licensing/license_key_fetcher.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher.rb
@@ -230,7 +230,7 @@ module ChefLicensing
         config[:start_interaction] = :prompt_license_about_to_expire
         prompt_fetcher.config = config
         false
-      elsif license.limit_exhausted?
+      elsif license.exhausted?
         config[:start_interaction] = :prompt_license_exhausted
         prompt_fetcher.config = config
         false

--- a/components/ruby/lib/chef-licensing/license_key_fetcher.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher.rb
@@ -86,8 +86,8 @@ module ChefLicensing
       end
 
       # Scenario: When a user is prompted for license expiry and license is not yet renewed
-      if %i{prompt_license_about_to_expire prompt_license_expired_local_mode prompt_license_exhausted}.include?(config[:start_interaction])
-        # Not blocking any license type in case of expiry
+      if %i{prompt_license_about_to_expire prompt_license_expired_local_mode prompt_commercial_license_exhausted}.include?(config[:start_interaction])
+        # Not blocking any license type in case of expiry or for commercial license exhaustion
         return @license_keys
       end
 
@@ -136,8 +136,8 @@ module ChefLicensing
       end
 
       # Scenario: When a user is prompted for license expiry and license is not yet renewed
-      if new_keys.empty? && %i{prompt_license_about_to_expire prompt_license_expired prompt_license_exhausted}.include?(config[:start_interaction])
-        # Not blocking any license type in case of expiry
+      if new_keys.empty? && %i{prompt_license_about_to_expire prompt_license_expired prompt_commercial_license_exhausted}.include?(config[:start_interaction])
+        # Not blocking any license type in case of expiry or for commercial license exhaustion
         return @license_keys
       end
 
@@ -230,8 +230,8 @@ module ChefLicensing
         config[:start_interaction] = :prompt_license_about_to_expire
         prompt_fetcher.config = config
         false
-      elsif license.exhausted?
-        config[:start_interaction] = :prompt_license_exhausted
+      elsif license.exhausted? && license.license_type == "commercial"
+        config[:start_interaction] = :prompt_commercial_license_exhausted
         prompt_fetcher.config = config
         false
       else

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
@@ -334,6 +334,17 @@ interactions:
     action: fetch_license_id
     paths: [exit]
 
+  prompt_license_exhausted:
+    messages: |
+      ------------------------------------------------------------
+        We hope you've been enjoying our Chef <%= input[:chef_product_name] %>!
+        However, it seems like you've exceeded your entitled usage limit on targets.
+        Reach out to our support team at <%= input[:pastel].underline.green("https://www.chef.io/contact-us")%>
+        for upgrading your targets limit to continue enjoying Chef <%= input[:chef_product_name] %>
+      ------------------------------------------------------------
+    prompt_type: "say"
+    paths: [fetch_license_id]
+
   exit:
     messages: ""
 

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
@@ -344,7 +344,7 @@ interactions:
         However, it appears that you have exceeded your entitled usage limit on <%= input[:unit_measure] %>.
 
         Reach out to our support team at <%= input[:pastel].underline.green("https://www.chef.io/contact-us")%>
-        For upgrading your <%= input[:unit_measure] %> limit to continue enjoying Chef <%= input[:chef_product_name] %>
+        for upgrading your <%= input[:unit_measure] %> limit to continue enjoying Chef <%= input[:chef_product_name] %>
       ------------------------------------------------------------
     prompt_type: "say"
     paths: [fetch_license_id]

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
@@ -337,8 +337,8 @@ interactions:
   prompt_license_exhausted:
     messages: |
       ------------------------------------------------------------
-        We hope you've been enjoying our Chef <%= input[:chef_product_name] %>!
-        However, it seems like you've exceeded your entitled usage limit on targets.
+        We hope you've been enjoying Chef <%= input[:chef_product_name] %>!
+        However, it appears that you have exceeded your entitled usage limit on targets.
         Reach out to our support team at <%= input[:pastel].underline.green("https://www.chef.io/contact-us")%>
         for upgrading your targets limit to continue enjoying Chef <%= input[:chef_product_name] %>
       ------------------------------------------------------------

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
@@ -195,12 +195,13 @@ interactions:
 
   validate_license_expiration:
     action: license_expiration_status?
-    paths: [validation_success, prompt_license_about_to_expire, prompt_license_expired, prompt_license_expired_local_mode]
+    paths: [validation_success, prompt_license_about_to_expire, prompt_license_expired, prompt_license_expired_local_mode, prompt_commercial_license_exhausted]
     response_path_map:
       "active": validation_success
       "about_to_expire": prompt_license_about_to_expire
       "expired": prompt_license_expired
       "expired_in_local_mode": prompt_license_expired_local_mode
+      "exhausted_commercial_license": prompt_commercial_license_exhausted
 
   validation_success:
     messages: "✔ [Success] License validated successfully."
@@ -334,7 +335,7 @@ interactions:
     action: fetch_license_id
     paths: [exit]
 
-  prompt_license_exhausted:
+  prompt_commercial_license_exhausted:
     messages: |
       ------------------------------------------------------------
         We hope you've been enjoying Chef <%= input[:chef_product_name] %>!

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
@@ -195,13 +195,13 @@ interactions:
 
   validate_license_expiration:
     action: license_expiration_status?
-    paths: [validation_success, prompt_license_about_to_expire, prompt_license_expired, prompt_license_expired_local_mode, prompt_commercial_license_exhausted]
+    paths: [validation_success, prompt_license_about_to_expire, prompt_license_expired, prompt_license_expired_local_mode, prompt_license_exhausted]
     response_path_map:
       "active": validation_success
       "about_to_expire": prompt_license_about_to_expire
       "expired": prompt_license_expired
       "expired_in_local_mode": prompt_license_expired_local_mode
-      "exhausted_commercial_license": prompt_commercial_license_exhausted
+      "exhausted_commercial_license": prompt_license_exhausted
 
   validation_success:
     messages: "✔ [Success] License validated successfully."
@@ -335,13 +335,16 @@ interactions:
     action: fetch_license_id
     paths: [exit]
 
-  prompt_commercial_license_exhausted:
+  prompt_license_exhausted:
     messages: |
       ------------------------------------------------------------
+        <%= input[:pastel].yellow("! [WARNING]")%> <%= input[:license_type].capitalize %> License Exhausted
+
         We hope you've been enjoying Chef <%= input[:chef_product_name] %>!
-        However, it appears that you have exceeded your entitled usage limit on targets.
+        However, it appears that you have exceeded your entitled usage limit on <%= input[:unit_measure] %>.
+
         Reach out to our support team at <%= input[:pastel].underline.green("https://www.chef.io/contact-us")%>
-        for upgrading your targets limit to continue enjoying Chef <%= input[:chef_product_name] %>
+        For upgrading your <%= input[:unit_measure] %> limit to continue enjoying Chef <%= input[:chef_product_name] %>
       ------------------------------------------------------------
     prompt_type: "say"
     paths: [fetch_license_id]

--- a/components/ruby/lib/chef-licensing/tui_engine/tui_actions.rb
+++ b/components/ruby/lib/chef-licensing/tui_engine/tui_actions.rb
@@ -66,7 +66,7 @@ module ChefLicensing
           input[:license_expiration_date] = Date.parse(license.expiration_date).strftime("%a, %d %b %Y")
           input[:number_of_days_in_expiration] = license.number_of_days_in_expiration
           "about_to_expire"
-        elsif license.exhausted? && license.license_type == "commercial"
+        elsif license.exhausted? && license.license_type.downcase == "commercial"
           "exhausted_commercial_license"
         else
           "active"

--- a/components/ruby/lib/chef-licensing/tui_engine/tui_actions.rb
+++ b/components/ruby/lib/chef-licensing/tui_engine/tui_actions.rb
@@ -67,6 +67,7 @@ module ChefLicensing
           input[:number_of_days_in_expiration] = license.number_of_days_in_expiration
           "about_to_expire"
         elsif license.exhausted? && license.license_type.downcase == "commercial"
+          input[:license_type] = license.license_type
           "exhausted_commercial_license"
         else
           "active"

--- a/components/ruby/lib/chef-licensing/tui_engine/tui_actions.rb
+++ b/components/ruby/lib/chef-licensing/tui_engine/tui_actions.rb
@@ -66,6 +66,8 @@ module ChefLicensing
           input[:license_expiration_date] = Date.parse(license.expiration_date).strftime("%a, %d %b %Y")
           input[:number_of_days_in_expiration] = license.number_of_days_in_expiration
           "about_to_expire"
+        elsif license.exhausted? && license.license_type == "commercial"
+          "exhausted_commercial_license"
         else
           "active"
         end

--- a/components/ruby/spec/chef_licensing_ux_spec.rb
+++ b/components/ruby/spec/chef_licensing_ux_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe ChefLicensing::TUIEngine do
   let(:exhausted_commercial_license) { "HA0D5BABCDEFG7X2E8SXYZ4MV4" }
   let(:exhausted_commercial_client_api_data) { JSON.parse(File.read("spec/fixtures/api_response_data/exhausted_commercial_client_api_response.json")) }
 
-
   # escape sequences for arrow keys
   let(:simulate_up_arrow) { "\e[A" }
   let(:simulate_down_arrow) { "\e[B" }

--- a/components/ruby/spec/chef_licensing_ux_spec.rb
+++ b/components/ruby/spec/chef_licensing_ux_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe ChefLicensing::TUIEngine do
   let(:valid_describe_api_data) { JSON.parse(File.read("spec/fixtures/api_response_data/valid_describe_api_response.json")) }
   let(:valid_free_license_key) { "free-c0832d2d-1111-1ec1-b1e5-011d182dc341-111" }
   let(:valid_free_license_key_2) { "free-c0832d2d-1111-1ec1-b1e5-011d182dc341-112" }
+  let(:exhausted_commercial_license) { "HA0D5BABCDEFG7X2E8SXYZ4MV4" }
+  let(:exhausted_commercial_client_api_data) { JSON.parse(File.read("spec/fixtures/api_response_data/exhausted_commercial_client_api_response.json")) }
+
 
   # escape sequences for arrow keys
   let(:simulate_up_arrow) { "\e[A" }
@@ -166,6 +169,16 @@ RSpec.describe ChefLicensing::TUIEngine do
       .with(body: user_details_payload.to_json)
       .to_return(body: trial_license_generation_success_response,
                 headers: { content_type: "application/json" })
+
+    stub_request(:get, "#{ChefLicensing::Config.license_server_url}/v1/validate")
+      .with(query: { licenseId: exhausted_commercial_license, version: 2 })
+      .to_return(body: { data: true, message: "License Id is valid", status_code: 200 }.to_json,
+                  headers: { content_type: "application/json" })
+
+    stub_request(:get, "#{ChefLicensing::Config.license_server_url}/v1/client")
+      .with(query: { licenseId: exhausted_commercial_license, entitlementId: ChefLicensing::Config.chef_entitlement_id })
+      .to_return(body: { data: exhausted_commercial_client_api_data, status_code: 200 }.to_json,
+                  headers: { content_type: "application/json" })
 
   end
 
@@ -868,6 +881,27 @@ RSpec.describe ChefLicensing::TUIEngine do
       expect(prompt.output.string).to include("Are you sure to skip this step?")
       expect(prompt.output.string).to include("! [WARNING] A license is required to continue using this product")
       expect(prompt.output.string).to include("License ID validation skipped!")
+    end
+  end
+
+  context "commercial license entry ux with exhausted limit" do
+    let(:start_interaction) { :start }
+
+    before do
+      prompt.input << "\n"
+      prompt.input << exhausted_commercial_license
+      prompt.input << "\n"
+      prompt.input.rewind
+    end
+
+    let(:tui_engine) { described_class.new(opts) }
+
+    it "exits successfully traversing through the interactions in expected order" do
+      expect { tui_engine.run_interaction(start_interaction) }.to_not raise_error
+      expect(tui_engine.traversed_interaction).to eq(%i{start ask_if_user_has_license_id ask_for_license_id validate_license_id_pattern validate_license_id_with_api validate_license_restriction validate_license_expiration prompt_license_exhausted fetch_license_id})
+      expect(prompt.output.string).to include("Commercial License Exhausted")
+      expect(prompt.output.string).to include("We hope you've been enjoying Chef")
+      expect(prompt.output.string).to include("However, it appears that you have exceeded your entitled usage limit")
     end
   end
 end

--- a/components/ruby/spec/fixtures/api_response_data/exhausted_commercial_client_api_response.json
+++ b/components/ruby/spec/fixtures/api_response_data/exhausted_commercial_client_api_response.json
@@ -1,0 +1,53 @@
+{
+  "cache": {
+    "lastModified": "2023-01-16T12:05:40Z",
+    "evaluatedOn": "2023-01-16T12:07:20.114370692Z",
+    "expires": "2023-01-17T12:07:20.114370783Z",
+    "cacheControl": "private,max-age:42460"
+  },
+  "client": {
+    "license": "Commercial",
+    "status": "Exhausted",
+    "changesTo": "Grace",
+    "changesOn": "2094-11-01",
+    "changesIn": "2000 days",
+    "usage": "Active",
+    "used": 2,
+    "limit": 2,
+    "measure": 2
+  },
+  "assets": [
+    {
+      "id": "assetguid1",
+      "name": "Test Asset 1"
+    },
+    {
+      "id": "assetguid2",
+      "name": "Test Asset 2"
+    }
+  ],
+  "features": [
+    {
+      "id": "featureguid1",
+      "name": "Test Feature 1"
+    },
+    {
+      "id": "featureguid2",
+      "name": "Test Feature 2"
+    }
+  ],
+  "entitlement": {
+    "id": "3ff52c37-e41f-4f6c-ad4d-365192205968",
+    "name": "Inspec",
+    "start": "2022-11-01",
+    "end": "2024-11-01",
+    "licenses": 2,
+    "limits": [
+      {
+        "measure": "nodes",
+        "amount": 2
+      }
+    ],
+    "entitled": false
+  }
+}

--- a/components/ruby/spec/license_key_fetcher_spec.rb
+++ b/components/ruby/spec/license_key_fetcher_spec.rb
@@ -942,7 +942,7 @@ RSpec.describe ChefLicensing::LicenseKeyFetcher do
 
         it "nags that it is about to expire" do
           license_key_fetcher.fetch_and_persist
-          expect(license_key_fetcher.config[:start_interaction]).to eq(:prompt_commercial_license_exhausted)
+          expect(license_key_fetcher.config[:start_interaction]).to eq(:prompt_license_exhausted)
         end
       end
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR implements the functionality and the UI to display when the target limit is exceeded for licenses available on the system.

### Screenshot
<img width="638" alt="image" src="https://github.com/chef/chef-licensing/assets/98935583/e7e17883-a4e6-4759-b835-3d9c605a712b">

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
CHEF-4925: Show a license enforcement message when a commercial user exceeds the purchased target limit

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
