### PR TITLE
CHEF-4924: Show a license enforcement message on exceeding target limit for free license

### DIFF
--- a/components/ruby/lib/chef-licensing/license_key_fetcher.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher.rb
@@ -88,7 +88,13 @@ module ChefLicensing
       # Scenario: When a user is prompted for license expiry and license is not yet renewed
       if %i{prompt_license_about_to_expire prompt_license_expired_local_mode prompt_license_exhausted}.include?(config[:start_interaction])
         # Not blocking any license type in case of expiry or for commercial license exhaustion
-        return @license_keys
+        if config[:start_interaction] == :prompt_license_exhausted
+          # If user has exhausted commercial license, we are not blocking
+          # we are blocking only when user has exhausted free license, hence LicenseKeyNotFetchedError is raised for free license
+          return @license_keys if license.license_type.downcase == "commercial"
+        else
+          return @license_keys
+        end
       end
 
       # Otherwise nothing was able to fetch a license. Throw an exception.
@@ -138,7 +144,13 @@ module ChefLicensing
       # Scenario: When a user is prompted for license expiry and license is not yet renewed
       if new_keys.empty? && %i{prompt_license_about_to_expire prompt_license_expired prompt_license_exhausted}.include?(config[:start_interaction])
         # Not blocking any license type in case of expiry or for commercial license exhaustion
-        return @license_keys
+        if config[:start_interaction] == :prompt_license_exhausted
+          # If user has exhausted commercial license, we are not blocking
+          # we are blocking only when user has exhausted free license, hence LicenseKeyNotFetchedError is raised for free license
+          return @license_keys if license.license_type.downcase == "commercial"
+        else
+          return @license_keys
+        end
       end
 
       # Otherwise nothing was able to fetch a license. Throw an exception.
@@ -230,7 +242,7 @@ module ChefLicensing
         config[:start_interaction] = :prompt_license_about_to_expire
         prompt_fetcher.config = config
         false
-      elsif license.exhausted? && license.license_type.downcase == "commercial"
+      elsif license.exhausted? && (license.license_type.downcase == "commercial" || license.license_type.downcase == "free")
         config[:start_interaction] = :prompt_license_exhausted
         prompt_fetcher.config = config
         false

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
@@ -201,7 +201,7 @@ interactions:
       "about_to_expire": prompt_license_about_to_expire
       "expired": prompt_license_expired
       "expired_in_local_mode": prompt_license_expired_local_mode
-      "exhausted_commercial_license": prompt_license_exhausted
+      "exhausted_license": prompt_license_exhausted
 
   validation_success:
     messages: "✔ [Success] License validated successfully."
@@ -347,7 +347,14 @@ interactions:
         for upgrading your <%= input[:unit_measure] %> limit to continue enjoying Chef <%= input[:chef_product_name] %>
       ------------------------------------------------------------
     prompt_type: "say"
-    paths: [fetch_license_id]
+    paths: [is_run_allowed_on_license_exhausted]
+
+  is_run_allowed_on_license_exhausted:
+    action: is_run_allowed_on_license_exhausted?
+    response_path_map:
+      "true": fetch_license_id
+      "false": exit
+    paths: [fetch_license_id, exit]
 
   exit:
     messages: ""

--- a/components/ruby/lib/chef-licensing/tui_engine/tui_actions.rb
+++ b/components/ruby/lib/chef-licensing/tui_engine/tui_actions.rb
@@ -66,12 +66,16 @@ module ChefLicensing
           input[:license_expiration_date] = Date.parse(license.expiration_date).strftime("%a, %d %b %Y")
           input[:number_of_days_in_expiration] = license.number_of_days_in_expiration
           "about_to_expire"
-        elsif license.exhausted? && license.license_type.downcase == "commercial"
+        elsif license.exhausted? && (license.license_type.downcase == "commercial" || license.license_type.downcase == "free")
           input[:license_type] = license.license_type
-          "exhausted_commercial_license"
+          "exhausted_license"
         else
           "active"
         end
+      end
+
+      def is_run_allowed_on_license_exhausted?(input)
+        input[:license_type].downcase == "commercial"
       end
 
       def fetch_license_id(input)

--- a/components/ruby/spec/chef_licensing_ux_spec.rb
+++ b/components/ruby/spec/chef_licensing_ux_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe ChefLicensing::TUIEngine do
   let(:valid_free_license_key_2) { "free-c0832d2d-1111-1ec1-b1e5-011d182dc341-112" }
   let(:exhausted_commercial_license) { "HA0D5BABCDEFG7X2E8SXYZ4MV4" }
   let(:exhausted_commercial_client_api_data) { JSON.parse(File.read("spec/fixtures/api_response_data/exhausted_commercial_client_api_response.json")) }
+  let(:exhausted_free_license) { "free-11eef3a8-1234-4b4c-567d-dd8c1234567d-890" }
+  let(:exhausted_free_client_api_data) { JSON.parse(File.read("spec/fixtures/api_response_data/exhausted_free_client_api_response.json")) }
 
   # escape sequences for arrow keys
   let(:simulate_up_arrow) { "\e[A" }
@@ -177,6 +179,16 @@ RSpec.describe ChefLicensing::TUIEngine do
     stub_request(:get, "#{ChefLicensing::Config.license_server_url}/v1/client")
       .with(query: { licenseId: exhausted_commercial_license, entitlementId: ChefLicensing::Config.chef_entitlement_id })
       .to_return(body: { data: exhausted_commercial_client_api_data, status_code: 200 }.to_json,
+                  headers: { content_type: "application/json" })
+
+    stub_request(:get, "#{ChefLicensing::Config.license_server_url}/v1/validate")
+      .with(query: { licenseId: exhausted_free_license, version: 2 })
+      .to_return(body: { data: true, message: "License Id is valid", status_code: 200 }.to_json,
+                headers: { content_type: "application/json" })
+
+    stub_request(:get, "#{ChefLicensing::Config.license_server_url}/v1/client")
+      .with(query: { licenseId: exhausted_free_license, entitlementId: ChefLicensing::Config.chef_entitlement_id })
+      .to_return(body: { data: exhausted_free_client_api_data, status_code: 200 }.to_json,
                   headers: { content_type: "application/json" })
 
   end
@@ -897,8 +909,29 @@ RSpec.describe ChefLicensing::TUIEngine do
 
     it "exits successfully traversing through the interactions in expected order" do
       expect { tui_engine.run_interaction(start_interaction) }.to_not raise_error
-      expect(tui_engine.traversed_interaction).to eq(%i{start ask_if_user_has_license_id ask_for_license_id validate_license_id_pattern validate_license_id_with_api validate_license_restriction validate_license_expiration prompt_license_exhausted fetch_license_id})
+      expect(tui_engine.traversed_interaction).to eq(%i{start ask_if_user_has_license_id ask_for_license_id validate_license_id_pattern validate_license_id_with_api validate_license_restriction validate_license_expiration prompt_license_exhausted is_run_allowed_on_license_exhausted fetch_license_id})
       expect(prompt.output.string).to include("Commercial License Exhausted")
+      expect(prompt.output.string).to include("We hope you've been enjoying Chef")
+      expect(prompt.output.string).to include("However, it appears that you have exceeded your entitled usage limit")
+    end
+  end
+
+  context "free license entry ux with exhausted limit" do
+    let(:start_interaction) { :start }
+
+    before do
+      prompt.input << "\n"
+      prompt.input << exhausted_free_license
+      prompt.input << "\n"
+      prompt.input.rewind
+    end
+
+    let(:tui_engine) { described_class.new(opts) }
+
+    it "exits successfully traversing through the interactions in expected order" do
+      expect { tui_engine.run_interaction(start_interaction) }.to_not raise_error
+      expect(tui_engine.traversed_interaction).to eq(%i{start ask_if_user_has_license_id ask_for_license_id validate_license_id_pattern validate_license_id_with_api validate_license_restriction validate_license_expiration prompt_license_exhausted is_run_allowed_on_license_exhausted})
+      expect(prompt.output.string).to include("Free License Exhausted")
       expect(prompt.output.string).to include("We hope you've been enjoying Chef")
       expect(prompt.output.string).to include("However, it appears that you have exceeded your entitled usage limit")
     end

--- a/components/ruby/spec/fixtures/api_response_data/exhausted_free_client_api_response.json
+++ b/components/ruby/spec/fixtures/api_response_data/exhausted_free_client_api_response.json
@@ -1,0 +1,53 @@
+{
+  "cache": {
+    "lastModified": "2023-01-16T12:05:40Z",
+    "evaluatedOn": "2023-01-16T12:07:20.114370692Z",
+    "expires": "2023-01-17T12:07:20.114370783Z",
+    "cacheControl": "private,max-age:42460"
+  },
+  "client": {
+    "license": "Free",
+    "status": "Exhausted",
+    "changesTo": "Grace",
+    "changesOn": "2094-11-01",
+    "changesIn": "2000 days",
+    "usage": "Active",
+    "used": 2,
+    "limit": 2,
+    "measure": 2
+  },
+  "assets": [
+    {
+      "id": "assetguid1",
+      "name": "Test Asset 1"
+    },
+    {
+      "id": "assetguid2",
+      "name": "Test Asset 2"
+    }
+  ],
+  "features": [
+    {
+      "id": "featureguid1",
+      "name": "Test Feature 1"
+    },
+    {
+      "id": "featureguid2",
+      "name": "Test Feature 2"
+    }
+  ],
+  "entitlement": {
+    "id": "3ff52c37-e41f-4f6c-ad4d-365192205968",
+    "name": "Inspec",
+    "start": "2022-11-01",
+    "end": "2024-11-01",
+    "licenses": 2,
+    "limits": [
+      {
+        "measure": "nodes",
+        "amount": 2
+      }
+    ],
+    "entitled": false
+  }
+}


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR implements the functionality and the UI to display when the target limit is exceeded for free licenses available on the system

### Screenshot
<img width="724" alt="image" src="https://github.com/chef/chef-licensing/assets/98935583/89a397d6-1188-4306-9845-643e2439bcf7">


## Related Issue
CHEF-4924: Show a license enforcement message when a free tier user exceeds the purchased target

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
