### PR TITLE
CHEF-10498: Add method to invoke warn message for non-commercial users

### DIFF
--- a/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
@@ -333,6 +333,27 @@ interactions:
 
   fetch_license_id:
     action: fetch_license_id
+    paths: [is_commercial_license]
+
+  is_commercial_license:
+    action: is_commercial_license?
+    response_path_map:
+      "true": exit
+      "false": warn_non_commercial_license
+    paths: [warn_non_commercial_license, exit]
+
+  warn_non_commercial_license:
+    messages: |
+      ------------------------------------------------------------
+        <%= input[:pastel].yellow("! [WARNING]")%> Non-Commercial License
+
+        This is a <%= input[:license_type].downcase %> product - not meant for commercial usage.
+
+        If you are using it for commercial purposes, please reach
+        out to our sales team at <%= input[:pastel].underline.green("chef-sales@progress.com")%> to get
+        commercial license to be compliant with Progress Chef MLSA.
+      ------------------------------------------------------------
+    prompt_type: "say"
     paths: [exit]
 
   prompt_license_exhausted:

--- a/components/ruby/lib/chef-licensing/tui_engine/tui_actions.rb
+++ b/components/ruby/lib/chef-licensing/tui_engine/tui_actions.rb
@@ -43,6 +43,9 @@ module ChefLicensing
       def is_license_allowed?(input)
         client_api_call(license_id)
         self.license_type = get_license_type
+        # When user enters the license via TUI, we need to check if the license type is commercial to display warnings.
+        input[:is_commercial] = license_type == :commercial ? true : false
+        input[:license_type] = license_type
         if license_restricted?(license_type)
           # Existing license keys needs to be fetcher to show details of existing license of license type which is restricted.
           # However, if user is trying to add Free Tier License, and user has active trial license, we fetch the trial license key
@@ -80,6 +83,10 @@ module ChefLicensing
 
       def fetch_license_id(input)
         license_id
+      end
+
+      def is_commercial_license?(input)
+        input[:is_commercial]
       end
 
       def fetch_invalid_license_msg(input)

--- a/components/ruby/spec/chef_licensing_ux_spec.rb
+++ b/components/ruby/spec/chef_licensing_ux_spec.rb
@@ -216,6 +216,8 @@ RSpec.describe ChefLicensing::TUIEngine do
       expect(prompt.output.string).to include("I already have a license ID")
       expect(prompt.output.string).to include("Please enter your license ID:")
       expect(prompt.output.string).to include("License validated successfully")
+      expect(prompt.output.string).to include("Non-Commercial License")
+      expect(prompt.output.string).to include("If you are using it for commercial purposes, please reach")
     end
   end
 
@@ -237,6 +239,8 @@ RSpec.describe ChefLicensing::TUIEngine do
       expect(prompt.output.string).to include("I already have a license ID")
       expect(prompt.output.string).to include("Please enter your license ID:")
       expect(prompt.output.string).to include("License validated successfully")
+      expect(prompt.output.string).to include("Non-Commercial License")
+      expect(prompt.output.string).to include("If you are using it for commercial purposes, please reach")
     end
   end
 
@@ -261,6 +265,8 @@ RSpec.describe ChefLicensing::TUIEngine do
       expect(prompt.output.string).to include("Please enter your license ID:")
       expect(output.string).to include("Malformed License Key passed on command line - should be ")
       expect(prompt.output.string).to include("License validated successfully")
+      expect(prompt.output.string).to include("Non-Commercial License")
+      expect(prompt.output.string).to include("If you are using it for commercial purposes, please reach")
     end
   end
 
@@ -741,6 +747,8 @@ RSpec.describe ChefLicensing::TUIEngine do
       expect(prompt.output.string).to include("Get a Commercial License to receive bug fixes, updates")
       expect(prompt.output.string).to include("Get a Free Tier License to scan limited targets.")
       expect(prompt.output.string).to_not include("license add")
+      expect(prompt.output.string).to include("Non-Commercial License")
+      expect(prompt.output.string).to include("If you are using it for commercial purposes, please reach")
     end
 
   end
@@ -756,6 +764,8 @@ RSpec.describe ChefLicensing::TUIEngine do
       expect(tui_engine.traversed_interaction).to eq(%i{prompt_license_about_to_expire fetch_license_id is_commercial_license warn_non_commercial_license})
       expect(prompt.output.string).to include("Your license is about to expire in")
       expect(prompt.output.string).to include("To avoid service disruptions, get a Commercial License")
+      expect(prompt.output.string).to include("Non-Commercial License")
+      expect(prompt.output.string).to include("If you are using it for commercial purposes, please reach")
     end
   end
 
@@ -851,6 +861,8 @@ RSpec.describe ChefLicensing::TUIEngine do
       expect(prompt.output.string).to include("Validate a generated license ID")
       expect(prompt.output.string).to include("Please enter your license ID:")
       expect(prompt.output.string).to include("License validated successfully")
+      expect(prompt.output.string).to include("Non-Commercial License")
+      expect(prompt.output.string).to include("If you are using it for commercial purposes, please reach")
     end
   end
 

--- a/components/ruby/spec/chef_licensing_ux_spec.rb
+++ b/components/ruby/spec/chef_licensing_ux_spec.rb
@@ -45,6 +45,8 @@ RSpec.describe ChefLicensing::TUIEngine do
     {
       chef_product_name: ChefLicensing::Config.chef_product_name&.capitalize,
       unit_measure: "targets",
+      is_commercial: false,
+      license_type: "trial",
     }
   }
 
@@ -210,7 +212,7 @@ RSpec.describe ChefLicensing::TUIEngine do
 
     it "exits successfully traversing through the interactions in expected order" do
       expect { tui_engine.run_interaction(start_interaction) }.to_not raise_error
-      expect(tui_engine.traversed_interaction).to eq(%i{start ask_if_user_has_license_id ask_for_license_id validate_license_id_pattern validate_license_id_with_api validate_license_restriction validate_license_expiration validation_success display_license_info fetch_license_id})
+      expect(tui_engine.traversed_interaction).to eq(%i{start ask_if_user_has_license_id ask_for_license_id validate_license_id_pattern validate_license_id_with_api validate_license_restriction validate_license_expiration validation_success display_license_info fetch_license_id is_commercial_license warn_non_commercial_license})
       expect(prompt.output.string).to include("I already have a license ID")
       expect(prompt.output.string).to include("Please enter your license ID:")
       expect(prompt.output.string).to include("License validated successfully")
@@ -231,7 +233,7 @@ RSpec.describe ChefLicensing::TUIEngine do
 
     it "exits successfully traversing through the interactions in expected order" do
       expect { tui_engine.run_interaction(start_interaction) }.to_not raise_error
-      expect(tui_engine.traversed_interaction).to eq(%i{start ask_if_user_has_license_id ask_for_license_id validate_license_id_pattern validate_license_id_with_api validate_license_restriction validate_license_expiration validation_success display_license_info fetch_license_id})
+      expect(tui_engine.traversed_interaction).to eq(%i{start ask_if_user_has_license_id ask_for_license_id validate_license_id_pattern validate_license_id_with_api validate_license_restriction validate_license_expiration validation_success display_license_info fetch_license_id is_commercial_license warn_non_commercial_license})
       expect(prompt.output.string).to include("I already have a license ID")
       expect(prompt.output.string).to include("Please enter your license ID:")
       expect(prompt.output.string).to include("License validated successfully")
@@ -254,7 +256,7 @@ RSpec.describe ChefLicensing::TUIEngine do
 
     it "exits successfully traversing through the interactions in expected order" do
       expect { tui_engine.run_interaction(start_interaction) }.to_not raise_error
-      expect(tui_engine.traversed_interaction).to eq(%i{start ask_if_user_has_license_id ask_for_license_id validate_license_id_pattern ask_for_license_id validate_license_id_pattern validate_license_id_with_api validate_license_restriction validate_license_expiration validation_success display_license_info fetch_license_id})
+      expect(tui_engine.traversed_interaction).to eq(%i{start ask_if_user_has_license_id ask_for_license_id validate_license_id_pattern ask_for_license_id validate_license_id_pattern validate_license_id_with_api validate_license_restriction validate_license_expiration validation_success display_license_info fetch_license_id is_commercial_license warn_non_commercial_license})
       expect(prompt.output.string).to include("I already have a license ID")
       expect(prompt.output.string).to include("Please enter your license ID:")
       expect(output.string).to include("Malformed License Key passed on command line - should be ")
@@ -328,6 +330,8 @@ RSpec.describe ChefLicensing::TUIEngine do
         validation_success
         display_license_info
         fetch_license_id
+        is_commercial_license
+        warn_non_commercial_license
       }
     }
 
@@ -554,6 +558,8 @@ RSpec.describe ChefLicensing::TUIEngine do
         validation_success
         display_license_info
         fetch_license_id
+        is_commercial_license
+        warn_non_commercial_license
       }
     }
 
@@ -713,7 +719,7 @@ RSpec.describe ChefLicensing::TUIEngine do
     it "shows the error message for expired license" do
       expect { tui_engine.append_info_to_input(additional_info_for_tui_engine) }.to_not raise_error
       expect { tui_engine.run_interaction(start_interaction) }.to_not raise_error
-      expect(tui_engine.traversed_interaction).to eq(%i{prompt_license_expired fetch_license_id})
+      expect(tui_engine.traversed_interaction).to eq(%i{prompt_license_expired fetch_license_id is_commercial_license warn_non_commercial_license})
       expect(prompt.output.string).to include("License Expired")
       expect(prompt.output.string).to include("Get a Commercial License to receive bug fixes, updates")
       expect(prompt.output.string).to include("Get a Free Tier License to scan limited targets.")
@@ -730,7 +736,7 @@ RSpec.describe ChefLicensing::TUIEngine do
     it "shows the error message for expired license" do
       expect { tui_engine.append_info_to_input(additional_info_for_tui_engine) }.to_not raise_error
       expect { tui_engine.run_interaction(start_interaction) }.to_not raise_error
-      expect(tui_engine.traversed_interaction).to eq(%i{prompt_license_expired_local_mode fetch_license_id})
+      expect(tui_engine.traversed_interaction).to eq(%i{prompt_license_expired_local_mode fetch_license_id is_commercial_license warn_non_commercial_license})
       expect(prompt.output.string).to include("License Expired")
       expect(prompt.output.string).to include("Get a Commercial License to receive bug fixes, updates")
       expect(prompt.output.string).to include("Get a Free Tier License to scan limited targets.")
@@ -745,8 +751,9 @@ RSpec.describe ChefLicensing::TUIEngine do
     let(:tui_engine) { described_class.new(opts) }
 
     it "shows the warning message for about to expire license" do
+      expect { tui_engine.append_info_to_input(additional_info_for_tui_engine) }.to_not raise_error
       expect { tui_engine.run_interaction(start_interaction) }.to_not raise_error
-      expect(tui_engine.traversed_interaction).to eq(%i{prompt_license_about_to_expire fetch_license_id})
+      expect(tui_engine.traversed_interaction).to eq(%i{prompt_license_about_to_expire fetch_license_id is_commercial_license warn_non_commercial_license})
       expect(prompt.output.string).to include("Your license is about to expire in")
       expect(prompt.output.string).to include("To avoid service disruptions, get a Commercial License")
     end
@@ -840,7 +847,7 @@ RSpec.describe ChefLicensing::TUIEngine do
 
     it "exits successfully traversing through the interactions in expected order" do
       expect { tui_engine.run_interaction(start_interaction) }.to_not raise_error
-      expect(tui_engine.traversed_interaction).to eq(%i{add_license_all ask_if_user_has_license_id_for_license_addition ask_for_license_id validate_license_id_pattern validate_license_id_with_api validate_license_restriction validate_license_expiration validation_success display_license_info fetch_license_id})
+      expect(tui_engine.traversed_interaction).to eq(%i{add_license_all ask_if_user_has_license_id_for_license_addition ask_for_license_id validate_license_id_pattern validate_license_id_with_api validate_license_restriction validate_license_expiration validation_success display_license_info fetch_license_id is_commercial_license warn_non_commercial_license})
       expect(prompt.output.string).to include("Validate a generated license ID")
       expect(prompt.output.string).to include("Please enter your license ID:")
       expect(prompt.output.string).to include("License validated successfully")
@@ -913,7 +920,7 @@ RSpec.describe ChefLicensing::TUIEngine do
 
     it "exits successfully traversing through the interactions in expected order" do
       expect { tui_engine.run_interaction(start_interaction) }.to_not raise_error
-      expect(tui_engine.traversed_interaction).to eq(%i{start ask_if_user_has_license_id ask_for_license_id validate_license_id_pattern validate_license_id_with_api validate_license_restriction validate_license_expiration prompt_license_exhausted is_run_allowed_on_license_exhausted fetch_license_id})
+      expect(tui_engine.traversed_interaction).to eq(%i{start ask_if_user_has_license_id ask_for_license_id validate_license_id_pattern validate_license_id_with_api validate_license_restriction validate_license_expiration prompt_license_exhausted is_run_allowed_on_license_exhausted fetch_license_id is_commercial_license})
       expect(prompt.output.string).to include("Commercial License Exhausted")
       expect(prompt.output.string).to include("We hope you've been enjoying Chef")
       expect(prompt.output.string).to include("However, it appears that you have exceeded your entitled usage limit")

--- a/components/ruby/spec/license_key_fetcher_spec.rb
+++ b/components/ruby/spec/license_key_fetcher_spec.rb
@@ -830,7 +830,7 @@ RSpec.describe ChefLicensing::LicenseKeyFetcher do
 
         it "does not nags that it is about to expire" do
           license_key_fetcher.fetch_and_persist
-          expect(license_key_fetcher.config[:start_interaction]).to eq(nil)
+          expect(license_key_fetcher.config[:start_interaction]).to eq(:warn_non_commercial_license)
         end
       end
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR introduces a method which displays a warning message for non-commercial users.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
CHEF-10498: Modify CLI reporter to show message regarding licensing to free and trial users

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
