### PR TITLE
CHEF-10500: Update message for trial license users upon expiry

### DIFF
--- a/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
@@ -90,9 +90,11 @@ interactions:
       ------------------------------------------------------------
         <%= input[:pastel].yellow("! [WARNING]")%> <%= input[:license_type] %> License Expired
 
-        Get a Commercial License to receive bug fixes, updates
-        and new features.
-        Get a Free Tier License to scan limited <%= input[:unit_measure] %>.
+        We hope you've been enjoying Chef <%= input[:chef_product_name] %>!
+        However, it seems like your license has expired.
+
+        Reach out to our sales team at <%= input[:pastel].underline.green("chef-sales@progress.com")%>
+        to move to commercial tier.
 
         To get a new license, run <%= input[:pastel].bold("#{ChefLicensing::Config.chef_executable_name} license add")%>
         and select a license type.
@@ -105,9 +107,11 @@ interactions:
       ------------------------------------------------------------
         <%= input[:pastel].yellow("! [WARNING]")%> <%= input[:license_type] %> License Expired
 
-        Get a Commercial License to receive bug fixes, updates
-        and new features.
-        Get a Free Tier License to scan limited <%= input[:unit_measure] %>.
+        We hope you've been enjoying Chef <%= input[:chef_product_name] %>!
+        However, it seems like your license has expired.
+
+        Reach out to our sales team at <%= input[:pastel].underline.green("chef-sales@progress.com")%>
+        to move to commercial tier.
       ------------------------------------------------------------
     prompt_type: "say"
     paths: [fetch_license_id]

--- a/components/ruby/spec/chef_licensing_ux_spec.rb
+++ b/components/ruby/spec/chef_licensing_ux_spec.rb
@@ -715,8 +715,9 @@ RSpec.describe ChefLicensing::TUIEngine do
       expect { tui_engine.run_interaction(start_interaction) }.to_not raise_error
       expect(tui_engine.traversed_interaction).to eq(%i{prompt_license_expired fetch_license_id})
       expect(prompt.output.string).to include("License Expired")
-      expect(prompt.output.string).to include("Get a Commercial License to receive bug fixes, updates")
-      expect(prompt.output.string).to include("Get a Free Tier License to scan limited targets.")
+      expect(prompt.output.string).to include("We hope you've been enjoying Chef Inspec!")
+      expect(prompt.output.string).to include("However, it seems like your license has expired.")
+      expect(prompt.output.string).to include("Reach out to our sales team at")
       expect(prompt.output.string).to include("license add")
     end
 
@@ -732,8 +733,9 @@ RSpec.describe ChefLicensing::TUIEngine do
       expect { tui_engine.run_interaction(start_interaction) }.to_not raise_error
       expect(tui_engine.traversed_interaction).to eq(%i{prompt_license_expired_local_mode fetch_license_id})
       expect(prompt.output.string).to include("License Expired")
-      expect(prompt.output.string).to include("Get a Commercial License to receive bug fixes, updates")
-      expect(prompt.output.string).to include("Get a Free Tier License to scan limited targets.")
+      expect(prompt.output.string).to include("We hope you've been enjoying Chef Inspec!")
+      expect(prompt.output.string).to include("However, it seems like your license has expired.")
+      expect(prompt.output.string).to include("Reach out to our sales team at")
       expect(prompt.output.string).to_not include("license add")
     end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR updates the message for trial license users upon expiry. Additionally, it adjusts the flow to exit the execution in case of an expired license.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
CHEF-10500: Update message for trial license users upon expiry

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
