### PR TITLE
Remove ruby 3.0 support from chef-licensing

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -18,16 +18,7 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:3.0
-
-- label: run-specs-ruby-3.0
-  command:
-    - cd /workdir/components/ruby
-    - ../../.expeditor/run_linux_tests.sh "rake spec"
-  expeditor:
-    executor:
-      docker:
-        image: ruby:3.0
+        image: ruby:3.1-bullseye
 
 - label: run-specs-ruby-3.1
   command:

--- a/components/ruby/chef-licensing.gemspec
+++ b/components/ruby/chef-licensing.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Chef License storage, generation, and entitlement}
   spec.description   = %q{Ruby library to support CLI tools that use Progress Chef license storage, generation, and entitlement.}
   spec.homepage      = "https://github.com/chef/chef-licensing"
-  spec.required_ruby_version = Gem::Requirement.new(">= 3.0.3")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/chef/chef-licensing"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Removes Ruby v3.0 support from chef-licensing
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
