### PR TITLE
CHEF-12730: make license list & license add cmds as dynamic text

### DIFF
--- a/components/ruby/lib/chef-licensing/config.rb
+++ b/components/ruby/lib/chef-licensing/config.rb
@@ -13,7 +13,7 @@ require_relative "licensing_service/local"
 module ChefLicensing
   class Config
     class << self
-      attr_writer :license_server_url, :logger, :output, :license_server_url_check_in_file
+      attr_writer :license_server_url, :logger, :output, :license_server_url_check_in_file, :license_add_command, :license_list_command
 
       # is_local_license_service is used by context class
       attr_accessor :is_local_license_service, :chef_entitlement_id, :chef_product_name, :chef_executable_name
@@ -38,6 +38,14 @@ module ChefLicensing
 
       def output
         @output ||= STDOUT
+      end
+
+      def license_add_command
+        @license_add_command ||= "license add"
+      end
+
+      def license_list_command
+        @license_list_command ||= "license list"
       end
     end
   end

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/chef_licensing_interactions.yaml
@@ -69,20 +69,20 @@ interactions:
 
   trial_restriction_message:
     prompt_type: "say"
-    messages:
-      Please generate a Free Tier or Commercial License by running <%= input[:pastel].bold("#{ChefLicensing::Config.chef_executable_name} license add")%>.
+    messages: |
+      Please generate a Free Tier or Commercial License by running <%= input[:pastel].bold("#{ChefLicensing::Config.chef_executable_name} #{ChefLicensing::Config.license_add_command}")%>.
     paths: [exit_with_message]
 
   free_restriction_message:
     prompt_type: "say"
-    messages:
-      Please generate a Trial or Commercial License by running <%= input[:pastel].bold("#{ChefLicensing::Config.chef_executable_name} license add")%>.
+    messages: |
+      Please generate a Trial or Commercial License by running <%= input[:pastel].bold("#{ChefLicensing::Config.chef_executable_name} #{ChefLicensing::Config.license_add_command}")%>.
     paths: [exit_with_message]
 
   only_commercial_allowed_message:
     prompt_type: "say"
-    messages:
-      Please generate a Commercial License by running <%= input[:pastel].bold("#{ChefLicensing::Config.chef_executable_name} license add")%>.
+    messages: |
+      Please generate a Commercial License by running <%= input[:pastel].bold("#{ChefLicensing::Config.chef_executable_name} #{ChefLicensing::Config.license_add_command}")%>.
     paths: [exit_with_message]
 
   prompt_license_expired:
@@ -96,7 +96,7 @@ interactions:
         Reach out to our sales team at <%= input[:pastel].underline.green("chef-sales@progress.com")%>
         to move to commercial tier.
 
-        To get a new license, run <%= input[:pastel].bold("#{ChefLicensing::Config.chef_executable_name} license add")%>
+        To get a new license, run <%= input[:pastel].bold("#{ChefLicensing::Config.chef_executable_name} #{ChefLicensing::Config.license_add_command}") %>
         and select a license type.
       ------------------------------------------------------------
     prompt_type: "say"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR makes the license list and license add command texts dynamic allowing applications to display customized help messages for these commands.

This is done to achieve product neutral message.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
CHEF-12730: Verify Messaging is Product Neutral

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
