### PR TITLE
CHEF-14142 Hard enforcement fix: Adding the same type of license

### DIFF
--- a/components/ruby/lib/chef-licensing/license_key_fetcher.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher.rb
@@ -290,8 +290,8 @@ module ChefLicensing
     end
 
     def get_license_type(license_key)
-      self.license = ChefLicensing.client(license_keys: [license_key])
-      license.license_type.downcase.to_sym
+      license_obj = ChefLicensing.client(license_keys: [license_key])
+      license_obj.license_type.downcase.to_sym
     end
 
     def license_restricted?(license_type)

--- a/components/ruby/lib/chef-licensing/license_key_fetcher.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher.rb
@@ -316,16 +316,21 @@ module ChefLicensing
         # However, if user is trying to add Free Tier License, and user has active trial license, we fetch the trial license key
         if license_type == :free && file_fetcher.user_has_active_trial_license?
           existing_license_keys_in_file = file_fetcher.fetch_license_keys_based_on_type(:trial)
-        else
+        elsif file_fetcher.user_has_active_license?
+          # Handling license addition restriction scenarios only if the current license is an active license
           existing_license_keys_in_file = file_fetcher.fetch_license_keys_based_on_type(license_type)
         end
         # Only prompt when a new trial license is added
-        unless existing_license_keys_in_file.last == new_keys.first
-          # prompt the message that this addition of license is restricted.
-          prompt_license_addition_restricted(license_type, existing_license_keys_in_file)
-          return false
+        if existing_license_keys_in_file
+          unless existing_license_keys_in_file.last == new_keys.first
+            # prompt the message that this addition of license is restricted.
+            prompt_license_addition_restricted(license_type, existing_license_keys_in_file)
+            return false
+          end
         end
-        true # license type is restricted but not the key since it is the same key hence returning true
+        # license addition should be restricted but it it not because the key is same as that of one user is trying to add
+        # license addition should be restricted but it it not because the license is expired and warning wont be handled by this restriction
+        true
       else
         persist_and_concat(new_keys, license_type)
         true

--- a/components/ruby/lib/chef-licensing/license_key_fetcher.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher.rb
@@ -328,8 +328,8 @@ module ChefLicensing
             return false
           end
         end
-        # license addition should be restricted but it it not because the key is same as that of one user is trying to add
-        # license addition should be restricted but it it not because the license is expired and warning wont be handled by this restriction
+        # license addition should be restricted but it is not because the key is same as that of one user is trying to add
+        # license addition should be restricted but it is not because the license is expired and warning wont be handled by this restriction
         true
       else
         persist_and_concat(new_keys, license_type)

--- a/components/ruby/lib/chef-licensing/license_key_fetcher.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher.rb
@@ -316,10 +316,11 @@ module ChefLicensing
         # However, if user is trying to add Free Tier License, and user has active trial license, we fetch the trial license key
         if license_type == :free && file_fetcher.user_has_active_trial_license?
           existing_license_keys_in_file = file_fetcher.fetch_license_keys_based_on_type(:trial)
-        elsif file_fetcher.user_has_active_license?
+        elsif file_fetcher.user_has_active_trial_or_free_license?
           # Handling license addition restriction scenarios only if the current license is an active license
           existing_license_keys_in_file = file_fetcher.fetch_license_keys_based_on_type(license_type)
         end
+
         # Only prompt when a new trial license is added
         if existing_license_keys_in_file
           unless existing_license_keys_in_file.last == new_keys.first

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/file.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/file.rb
@@ -67,6 +67,11 @@ module ChefLicensing
         @active_trial_status
       end
 
+      def user_has_active_license?
+        return false unless contents&.key?(:licenses)
+        return ChefLicensing.client(license_keys: [contents[:licenses].last[:license_key]]).active?
+      end
+
       def fetch_allowed_license_types_for_addition
         license_types = %i{free trial commercial}
         existing_license_types = fetch_license_types

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/file.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/file.rb
@@ -69,7 +69,8 @@ module ChefLicensing
 
       def user_has_active_license?
         return false unless contents&.key?(:licenses)
-        return ChefLicensing.client(license_keys: [contents[:licenses].last[:license_key]]).active?
+
+        ChefLicensing.client(license_keys: [contents[:licenses].last[:license_key]]).active?
       end
 
       def fetch_allowed_license_types_for_addition

--- a/components/ruby/lib/chef-licensing/license_key_fetcher/file.rb
+++ b/components/ruby/lib/chef-licensing/license_key_fetcher/file.rb
@@ -67,10 +67,13 @@ module ChefLicensing
         @active_trial_status
       end
 
-      def user_has_active_license?
+      def user_has_active_trial_or_free_license?
+        read_license_key_file
         return false unless contents&.key?(:licenses)
 
-        ChefLicensing.client(license_keys: [contents[:licenses].last[:license_key]]).active?
+        all_license_keys = contents[:licenses].collect { |license| license[:license_key] }
+        license_obj = ChefLicensing.client(license_keys: all_license_keys)
+        (%w{trial free}.include? license_obj.license_type&.downcase) && license_obj.active?
       end
 
       def fetch_allowed_license_types_for_addition

--- a/components/ruby/spec/fixtures/api_response_data/valid_client_api_response.json
+++ b/components/ruby/spec/fixtures/api_response_data/valid_client_api_response.json
@@ -6,7 +6,7 @@
     "cacheControl": "private,max-age:42460"
   },
   "client": {
-    "license": "Trial",
+    "license": "trial",
     "status": "Active",
     "changesTo": "Grace",
     "changesOn": "2024-11-01",

--- a/components/ruby/spec/license_key_fetcher_spec.rb
+++ b/components/ruby/spec/license_key_fetcher_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe ChefLicensing::LicenseKeyFetcher do
 
   let(:describe_api_data) { JSON.parse(File.read("spec/fixtures/api_response_data/valid_describe_api_response.json")) }
   let(:client_api_data) { JSON.parse(File.read("spec/fixtures/api_response_data/valid_client_api_response.json")) }
+  let(:client_api_free_license_data) { JSON.parse(File.read("spec/fixtures/api_response_data/valid_client_api_response_free_license.json")) }
 
   before do
     ChefLicensing.configure do |config|
@@ -201,7 +202,7 @@ RSpec.describe ChefLicensing::LicenseKeyFetcher do
                     headers: { content_type: "application/json" })
         stub_request(:get, "#{ChefLicensing::Config.license_server_url}/v1/client")
           .with(query: { licenseId: "free-c0832d2d-1111-1ec1-b1e5-011d182dc341-111", entitlementId: ChefLicensing::Config.chef_entitlement_id })
-          .to_return(body: { data: client_api_data, status_code: 200 }.to_json,
+          .to_return(body: { data: client_api_free_license_data, status_code: 200 }.to_json,
                   headers: { content_type: "application/json" })
         stub_request(:get, "#{ChefLicensing::Config.license_server_url}/v1/client")
           .with(query: { licenseId: license_keys.join(","), entitlementId: ChefLicensing::Config.chef_entitlement_id })
@@ -237,7 +238,7 @@ RSpec.describe ChefLicensing::LicenseKeyFetcher do
                   headers: { content_type: "application/json" })
         stub_request(:get, "#{ChefLicensing::Config.license_server_url}/v1/client")
           .with(query: { licenseId: "free-c0832d2d-1111-1ec1-b1e5-011d182dc341-111", entitlementId: ChefLicensing::Config.chef_entitlement_id })
-          .to_return(body: { data: client_api_data, status_code: 200 }.to_json,
+          .to_return(body: { data: client_api_free_license_data, status_code: 200 }.to_json,
                   headers: { content_type: "application/json" })
         stub_request(:get, "#{ChefLicensing::Config.license_server_url}/v1/client")
           .with(query: { licenseId: license_keys.join(","), entitlementId: ChefLicensing::Config.chef_entitlement_id })
@@ -353,11 +354,11 @@ RSpec.describe ChefLicensing::LicenseKeyFetcher do
                 headers: { content_type: "application/json" })
         stub_request(:get, "#{ChefLicensing::Config.license_server_url}/v1/client")
           .with(query: { licenseId: "free-c0832d2d-1111-1ec1-b1e5-011d182dc341-111", entitlementId: ChefLicensing::Config.chef_entitlement_id })
-          .to_return(body: { data: client_api_data, status_code: 200 }.to_json,
+          .to_return(body: { data: client_api_free_license_data, status_code: 200 }.to_json,
                   headers: { content_type: "application/json" })
         stub_request(:get, "#{ChefLicensing::Config.license_server_url}/v1/client")
           .with(query: { licenseId: "free-c0832d2d-1111-1ec1-b1e5-011d182dc341-112", entitlementId: ChefLicensing::Config.chef_entitlement_id })
-          .to_return(body: { data: client_api_data, status_code: 200 }.to_json,
+          .to_return(body: { data: client_api_free_license_data, status_code: 200 }.to_json,
                 headers: { content_type: "application/json" })
         stub_request(:get, "#{ChefLicensing::Config.license_server_url}/v1/desc")
           .with(query: { licenseId: "free-c0832d2d-1111-1ec1-b1e5-011d182dc341-112", entitlementId: ChefLicensing::Config.chef_entitlement_id })


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Hard enforcement fix: Adding the same type of license using argument or env.

- If the user already has an expired trial license. After that, if the user tries to add an active trial license via argument `--chef-license-key` or via env variables `CHEF_LICENSE_KEY` it lets the user continue using InSpec. While it should enforce the user.

- If the user already has an exhausted free license. After that, if the user tries to add an active free license via argument `--chef-license-key` or via env variables `CHEF_LICENSE_KEY` it lets the user continue using InSpec. While it should enforce the user.
- ## Related Issue

<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
