### PR TITLE
Improve entitlement error handling during `fetch_and_persist`

### DIFF
--- a/components/ruby/lib/chef-licensing.rb
+++ b/components/ruby/lib/chef-licensing.rb
@@ -54,6 +54,13 @@ module ChefLicensing
     # @note fetch_and_persist is invoked by chef-products to fetch and persist the license keys
     def fetch_and_persist
       ChefLicensing::LicenseKeyFetcher.fetch_and_persist
+    rescue ChefLicensing::ClientError => e
+      # Checking specific text phrase for entitlement error
+      if e.message.match?(/not entitled/)
+        raise(ChefLicensing::SoftwareNotEntitled, "Software is not entitled.")
+      else
+        raise
+      end
     end
 
     def list_license_keys_info(opts = {})


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

This PR enhances the `fetch_and_persist` method to specifically handle entitlement errors. 

If a `ChefLicensing::ClientError` indicates a lack of entitlement, the method now raises a `ChefLicensing::SoftwareNotEntitled` exception. Other errors are re-raised as before.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
