### PR TITLE
[CHEF-21374] Using debug to warn the user about the connection failure to the lice…

### DIFF
--- a/components/ruby/lib/chef-licensing/restful_client/base.rb
+++ b/components/ruby/lib/chef-licensing/restful_client/base.rb
@@ -111,7 +111,7 @@ module ChefLicensing
           logger.debug "Connection succeeded to #{url}"
           break response
         rescue RestfulClientConnectionError
-          logger.warn "Connection failed to #{url}"
+          logger.debug "Connection failed to #{url}"
         rescue URI::InvalidURIError
           logger.warn "Invalid URI #{url}"
         end


### PR DESCRIPTION
…nsing server

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
With the removal of licensing changes from the various Chef products, the knife-18 changes are allowed to continue as it is. However, when the knife is in an air-gapped environment, there shouldn't be a warning stating that the connection to services.chef.io failed.

Hence, changing the logging type to debug from warn, so that the user will have more information if they use the debug mode, and the error will not be visible in the normal scenario. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
