### PR TITLE
CHEF-25725 - Add Optional mode conditions for Software & Feature Entitlement checks

### DIFF
--- a/components/ruby/lib/chef-licensing.rb
+++ b/components/ruby/lib/chef-licensing.rb
@@ -23,6 +23,9 @@ module ChefLicensing
     end
 
     def check_feature_entitlement!(feature_name: nil, feature_id: nil)
+      # If licensing is optional, bypass entitlement checks
+      return true if ChefLicensing::Config.make_licensing_optional
+
       # Checking for feature presence in license feature entitlements
       license = client(license_keys: license_keys)
       feature_entitlements = license.feature_entitlements.select { |feature| feature.id == feature_id || feature.name == feature_name }

--- a/components/ruby/lib/chef-licensing.rb
+++ b/components/ruby/lib/chef-licensing.rb
@@ -36,8 +36,10 @@ module ChefLicensing
     def check_software_entitlement!
       # If API call is not breaking that means license is entitled.
       unless ChefLicensing::Config.make_licensing_optional
-        raise ChefLicensing::LicenseKeyFetcher::LicenseKeyNotFetchedError,
-              "Unable to obtain a License Key." if license_keys.empty?
+        if license_keys.empty?
+          raise ChefLicensing::LicenseKeyFetcher::LicenseKeyNotFetchedError,
+                "Unable to obtain a License Key."
+        end
 
         client(license_keys: license_keys)
       end

--- a/components/ruby/lib/chef-licensing.rb
+++ b/components/ruby/lib/chef-licensing.rb
@@ -35,9 +35,12 @@ module ChefLicensing
 
     def check_software_entitlement!
       # If API call is not breaking that means license is entitled.
-      raise ChefLicensing::LicenseKeyFetcher::LicenseKeyNotFetchedError.new("Unable to obtain a License Key.") if license_keys.empty?
+      unless ChefLicensing::Config.make_licensing_optional
+        raise ChefLicensing::LicenseKeyFetcher::LicenseKeyNotFetchedError,
+              "Unable to obtain a License Key." if license_keys.empty?
 
-      client(license_keys: license_keys)
+        client(license_keys: license_keys)
+      end
       true
     rescue ChefLicensing::ClientError => e
       # Checking specific text phrase for entitlement error

--- a/components/ruby/spec/chef_licensing_spec.rb
+++ b/components/ruby/spec/chef_licensing_spec.rb
@@ -98,6 +98,16 @@ RSpec.describe ChefLicensing do
 
       it { expect { subject }.to raise_error(ChefLicensing::ClientError) }
     end
+
+    context "when licensing is optional" do
+      before do
+        allow(ChefLicensing::Config).to receive(:make_licensing_optional).and_return(true)
+      end
+
+      it "returns true without checking license" do
+        expect(described_class.check_feature_entitlement!(feature_name: feature, feature_id: nil)).to eq(true)
+      end
+    end
   end
 
   describe ".check_software_entitlement!" do
@@ -148,6 +158,16 @@ RSpec.describe ChefLicensing do
 
       it { expect { subject }.to raise_error(ChefLicensing::ClientError) }
     end
+
+    context "when licensing is optional" do
+      before do
+        allow(ChefLicensing::Config).to receive(:make_licensing_optional).and_return(true)
+      end
+
+      it "returns true without checking license" do
+        expect(described_class.check_software_entitlement!).to eq(true)
+      end
+    end
   end
 
   describe ".configure" do
@@ -171,6 +191,18 @@ RSpec.describe ChefLicensing do
       expect(ChefLicensing::Config.chef_product_name).to eq(chef_product_name)
       expect(ChefLicensing::Config.chef_entitlement_id).to eq(chef_entitlement_id)
       expect(ChefLicensing::Config.logger).to eq(logger)
+    end
+
+    context "when configuring optional licensing" do
+      before do
+        described_class.configure do |config|
+          config.make_licensing_optional = true
+        end
+      end
+
+      it "sets the make_licensing_optional configuration" do
+        expect(ChefLicensing::Config.make_licensing_optional).to eq(true)
+      end
     end
   end
 

--- a/components/ruby/spec/chef_licensing_ux_spec.rb
+++ b/components/ruby/spec/chef_licensing_ux_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe ChefLicensing::TUIEngine do
       config.license_server_url_check_in_file = true
       config.chef_product_name = "inspec"
       config.chef_entitlement_id = "3ff52c37-e41f-4f6c-ad4d-365192205968"
+      config.make_licensing_optional = false # <-- Ensure licensing is not optional
     end
   end
 
@@ -382,6 +383,7 @@ RSpec.describe ChefLicensing::TUIEngine do
         end
         ChefLicensing::Context.current_context = nil
         license_key_fetcher.fetch_and_persist
+        ChefLicensing::Context.current_context = nil # <-- Ensure context is reset after persisting
       end
 
       it "checks if the license is persister" do
@@ -393,7 +395,7 @@ RSpec.describe ChefLicensing::TUIEngine do
         prompt.input << valid_free_license_key_2
         prompt.input << "\n"
         prompt.input.rewind
-        ChefLicensing::Context.current_context = nil
+        ChefLicensing::Context.current_context = nil # <-- Ensure context is reset before running TUI
       end
 
       let(:expected_flow_for_license_restriction) {
@@ -609,6 +611,11 @@ RSpec.describe ChefLicensing::TUIEngine do
       before do
         ChefLicensing::Context.current_context = nil
         license_key_fetcher.fetch_and_persist
+
+        # Add missing stub for /v1/listLicenses for trial license
+        stub_request(:get, "#{ChefLicensing::Config.license_server_url}/v1/listLicenses")
+          .to_return(body: { data: [], status_code: 404 }.to_json,
+                     headers: { content_type: "application/json" })
       end
 
       it "checks if the license is persisted" do

--- a/components/ruby/spec/license_key_fetcher_spec.rb
+++ b/components/ruby/spec/license_key_fetcher_spec.rb
@@ -132,6 +132,7 @@ RSpec.describe ChefLicensing::LicenseKeyFetcher do
         ChefLicensing.configure do |config|
           config.is_local_license_service = nil
           config.license_server_url = "http://localhost-license-server/License"
+          config.make_licensing_optional = false # <-- Ensure licensing is not optional
         end
         stub_request(:get, "#{ChefLicensing::Config.license_server_url}/v1/listLicenses")
           .to_return(body: { data: ["tmns-0f76efaf-b45b-4d92-86b2-2d144ce73dfa-150"], status_code: 200 }.to_json,


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Skip license entitlement check when licensing is optional

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This change updates the logic to bypass the entitlement checks when 
ChefLicensing::Config.make_licensing_optional is true.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
