### PR TITLE
Updating Activesupport version to match chef

### DIFF
--- a/components/ruby/chef-licensing.gemspec
+++ b/components/ruby/chef-licensing.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "tty-prompt", "~> 0.23"
   spec.add_dependency "faraday", ">= 1", "< 2"
   spec.add_dependency "faraday-http-cache"
-  spec.add_dependency "activesupport", "~> 7.2", ">= 7.2.2.1"
+  spec.add_dependency "activesupport", "> 7.1.3.2", "< 7.2"
   spec.add_dependency "tty-spinner", "~> 0.9.3"
   spec.add_dependency "mixlib-log", "~> 3.0"
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Activesupport had some CVE's. Chef is being conservative in the version it updates to so we constrained it to anything between 7.1.3.2 and 7.2.2.2.  We were worried about other versions creeping in and adding complexity or incompatibility. This was tested against Ruby 3.1.7

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
