### PR TITLE
CHEF-33010 Added grype scan config

### DIFF
--- a/.github/workflows/ci-main-pull-request-stub.yml
+++ b/.github/workflows/ci-main-pull-request-stub.yml
@@ -88,6 +88,11 @@ jobs:
       perform-language-linting: true    # Perform language-specific linting and pre-compilation checks
       perform-trufflehog-scan: true
       perform-trivy-scan: true
+
+      # grype vulnerability scanning
+      perform-grype-scan: true
+      grype-fail-on-high: true
+      grype-fail-on-critical: true
              
       # perform application build and unit testing, will use custom repository properties when implemented for chef-primary-application, chef-build-profile, and chef-build-language
       build: true
@@ -152,6 +157,7 @@ jobs:
 
       # perform Blackduck software composition analysis (SCA) for 3rd party CVEs, licensing, and operational risk
       perform-blackduck-sca-scan: true # combined with generate sbom & generate github-sbom, also needs version above
+      run-bundle-install: true # generate Gemfile.lock at runtime for SBOM pipeline
       blackduck-project-group-name: 'Chef-Agents' # typically one of (Chef), Chef-Agents, Chef-Automate, Chef-Chef360, Chef-Habitat, Chef-Infrastructure-Server, Chef-Shared-Services, Chef-Non-Product'
       blackduck-project-name: ${{ github.event.repository.name }} # BlackDuck project name, typically the repository name
   


### PR DESCRIPTION
This PR updates the CI workflow configuration to enable Grype vulnerability scanning and renames the stub file to remove the version suffix.

- Renamed versioned stub to `ci-main-pull-request-stub.yml`
- Enabled Grype vulnerability scanning (`perform-grype-scan: true`)
- Configured build failure on high/critical vulnerabilities
- Added `run-bundle-install: true` to generate `Gemfile.lock` at runtime for the SBOM/BlackDuck SCA pipeline